### PR TITLE
Horizontal scroll by Shift+wheel

### DIFF
--- a/kpViewScrollableContainer.cpp
+++ b/kpViewScrollableContainer.cpp
@@ -1035,7 +1035,13 @@ void kpViewScrollableContainer::wheelEvent(QWheelEvent *e)
     }
 
     if (!e->isAccepted()) {
-        QScrollArea::wheelEvent(e);
+        if ((e->modifiers() & Qt::ShiftModifier) == 0)
+            QScrollArea::wheelEvent(e);
+        else
+        {
+            e->setModifiers(e->modifiers() & ~Qt::ShiftModifier);
+            horizontalScrollBar()->event(e);
+        }
     }
 }
 


### PR DESCRIPTION
On my Debian (Qt5) Shift+wheel only accelerates vertical scrolling in Kolourpaint, while in all other apps it scrolls horizontally. So Kolourpaint users must move bottom scrollbar by mouse which is unconvenient. This commit gives to Shift+wheel expected behavior.