### PR TITLE
Ribbon UI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,11 +348,14 @@ ecm_add_app_icon(kolourpaint_SRCS ICONS
 
 add_executable(kolourpaint ${kolourpaint_SRCS})
 
+find_package(SARibbonBar REQUIRED)
+
 target_link_libraries(kolourpaint
     KF${KF_MAJOR_VERSION}::XmlGui
     KF${KF_MAJOR_VERSION}::KIOFileWidgets
     KF${KF_MAJOR_VERSION}::TextWidgets
     Qt${QT_MAJOR_VERSION}::PrintSupport
+    SARibbonBar::SARibbonBar
     kolourpaint_lgpl
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,6 +213,7 @@ set(kolourpaint_lib2_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/mainWindow/kpMainWindow_Edit.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainWindow/kpMainWindow_File.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainWindow/kpMainWindow_Image.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/mainWindow/kpMainWindow_Ribbon.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainWindow/kpMainWindow_Settings.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainWindow/kpMainWindow_StatusBar.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mainWindow/kpMainWindow_Text.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,6 +318,7 @@ set(kolourpaint_app_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/widgets/toolbars/kpColorToolBar.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/widgets/toolbars/kpToolToolBar.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/widgets/toolbars/options/kpToolWidgetBase.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/widgets/toolbars/options/kpToolWidgetBase_ribbon.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/widgets/toolbars/options/kpToolWidgetBrush.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/widgets/toolbars/options/kpToolWidgetEraserSize.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/widgets/toolbars/options/kpToolWidgetFillStyle.cpp

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 Ribbon branch
 =============
 
-The old windows (like the colour window) are still created, they are just hidden. They couldn't be removed because their state (eg. of the colour widget) is used as the source of truth by the application and moving these into new variables inside the kpMainWindow class would take a larger re-write which is outside the scope of this branch. As such, the ribbon modifies the state of the widgets in the original, hidden, dialogs.
+![](https://invent.kde.org/-/project/2493/uploads/6f02a3879549cd0bf5bd109f1ed3e192/Screenshot_20250710_034048.png)
+
+This branch requires [SARibbon](https://github.com/czyt1988/SARibbon) to be installed.
+
+The old kp*ToolBar's are still created, they are just hidden. They couldn't be removed because their state (eg. of the colour widget) is used as the prime source of truth by the application and moving these into new variables inside the kpMainWindow class would take a larger re-write which is outside the scope of this branch. As such, the ribbon modifies the state of the widgets in the original, hidden, dialogs.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+Ribbon branch
+=============
+
+The old windows (like the colour window) are still created, they are just hidden. They couldn't be removed because their state (eg. of the colour widget) is used as the source of truth by the application and moving these into new variables inside the kpMainWindow class would take a larger re-write which is outside the scope of this branch. As such, the ribbon modifies the state of the widgets in the original, hidden, dialogs.
+
+---
 
 http://www.kolourpaint.org/
 

--- a/commands/kpCommandHistoryBase.cpp
+++ b/commands/kpCommandHistoryBase.cpp
@@ -227,6 +227,16 @@ void kpCommandHistoryBase::setUndoMaxLimitSizeLimit (kpCommandSize::SizeType siz
     trimCommandListsUpdateActions ();
 }
 
+KToolBarPopupAction *kpCommandHistoryBase::actionUndo()
+{
+    return m_actionUndo;
+}
+
+KToolBarPopupAction *kpCommandHistoryBase::actionRedo()
+{
+    return m_actionRedo;
+}
+
 
 // public
 void kpCommandHistoryBase::readConfig ()

--- a/commands/kpCommandHistoryBase.h
+++ b/commands/kpCommandHistoryBase.h
@@ -76,6 +76,9 @@ public:
     kpCommandSize::SizeType undoMaxLimitSizeLimit () const;
     void setUndoMaxLimitSizeLimit (kpCommandSize::SizeType sizeLimit);
 
+    KToolBarPopupAction *actionUndo();
+    KToolBarPopupAction *actionRedo();
+
 public:
     // Read and write above config
     void readConfig ();

--- a/environments/tools/kpToolEnvironment.h
+++ b/environments/tools/kpToolEnvironment.h
@@ -153,7 +153,6 @@ public:
 
     static bool drawAntiAliased;
 
-
 private:
     struct kpToolEnvironmentPrivate * const d;
 };

--- a/kolourpaintui.rc
+++ b/kolourpaintui.rc
@@ -4,7 +4,7 @@ SYNC: Do not change the number of quotes before the version number
       - it is parsed by the KolourPaint wrapper shell script (in standalone
       backport releases of KolourPaint)
 -->
-<gui name="kolourpaint" version="75">
+<gui name="kolourpaint" version="76">
 
 <!--
 SYNC: Check for duplicate actions in menus caused by some of our actions
@@ -111,6 +111,7 @@ SYNC: Check for duplicate actions in menus caused by some of our actions
     </Menu>
 
     <Menu name="settings">
+        <Action name="settings_show_ribbon" append="show_merge" />
         <Action name="settings_show_path" append="show_merge" />
         <Action name="settings_draw_antialiased" append="show_merge" />
     </Menu>

--- a/kpDefs.h
+++ b/kpDefs.h
@@ -62,6 +62,7 @@
 #define kpSettingShowGrid "Show Grid"
 #define kpSettingShowPath "Show Path"
 #define kpSettingDrawAntiAliased "Draw AntiAliased"
+#define kpSettingShowRibbon "Show Ribbon"
 #define kpSettingColorSimilarity "Color Similarity"
 #define kpSettingDitherOnOpen "Dither on Open if Screen is 15/16bpp and Image Num Colors More Than"
 #define kpSettingPrintImageCenteredOnPage "Print Image Centered On Page"

--- a/mainWindow/kpMainWindow.cpp
+++ b/mainWindow/kpMainWindow.cpp
@@ -259,7 +259,7 @@ void kpMainWindow::init ()
     auto vbox = new QVBoxLayout(container);
 
     auto rwidg = new SARibbonWidget(container);
-    // rwidg->setRibbonTheme(SARibbonTheme::RibbonThemeOffice2016Blue);
+    rwidg->setRibbonTheme(SARibbonTheme::RibbonThemeOffice2016Blue);
     d->ribbon = rwidg->ribbonBar();
     setupRibbon();
     vbox->addWidget(rwidg);

--- a/mainWindow/kpMainWindow.cpp
+++ b/mainWindow/kpMainWindow.cpp
@@ -53,6 +53,7 @@
 
 #include <QMenu>
 #include <QDropEvent>
+#include <QVBoxLayout>
 
 #include "kpLogCategories.h"
 
@@ -216,6 +217,7 @@ void kpMainWindow::init ()
     setupActions ();
     createStatusBar ();
     createGUI ();
+    // This is where the Ribbon setup code goes
 
     createColorBox ();
     createToolBox ();
@@ -253,7 +255,19 @@ void kpMainWindow::init ()
     connect (d->scrollView, &kpViewScrollableContainer::contentsMoved,
              this, &kpMainWindow::slotScrollViewAfterScroll);
 
-    setCentralWidget (d->scrollView);
+    auto container = new QWidget(this);
+    auto vbox = new QVBoxLayout(container);
+
+    auto rwidg = new SARibbonWidget(container);
+    d->ribbon = rwidg->ribbonBar();
+    setupRibbon();
+    vbox->addWidget(rwidg);
+    // setMenuWidget(ribbon);    // https://doc.qt.io/qt-6/qmainwindow.html#setMenuWidget
+
+    d->scrollView->setParent(container);
+    vbox->addWidget(d->scrollView);
+
+    setCentralWidget (container);
 
     //
     // set initial pos/size of GUI

--- a/mainWindow/kpMainWindow.cpp
+++ b/mainWindow/kpMainWindow.cpp
@@ -478,7 +478,7 @@ kpColorToolBar *kpMainWindow::colorToolBar () const
 // public
 kpColorCells *kpMainWindow::colorCells () const
 {
-    return d->colorToolBar ? d->colorToolBar->colorCells () : nullptr;
+    return m_colorCells;
 }
 
 //---------------------------------------------------------------------

--- a/mainWindow/kpMainWindow.cpp
+++ b/mainWindow/kpMainWindow.cpp
@@ -220,8 +220,6 @@ void kpMainWindow::init ()
     // This is where the Ribbon setup code goes
 
     createColorBox ();
-    createToolBox ();
-
 
     // Let the Tool Box take all the vertical space, since it can be quite
     // tall with all its tool option widgets.  This also avoids occasional
@@ -269,6 +267,7 @@ void kpMainWindow::init ()
     vbox->addWidget(d->scrollView);
 
     setCentralWidget (container);
+    createToolBox ();
 
     //
     // set initial pos/size of GUI

--- a/mainWindow/kpMainWindow.cpp
+++ b/mainWindow/kpMainWindow.cpp
@@ -109,6 +109,7 @@ void kpMainWindow::readGeneralSettings ()
     d->configFirstTime = cfg.readEntry (kpSettingFirstTime, true);
     d->configShowGrid = cfg.readEntry (kpSettingShowGrid, false);
     d->configShowPath = cfg.readEntry (kpSettingShowPath, false);
+    d->configShowRibbon = cfg.readEntry (kpSettingShowRibbon, true);
     d->moreEffectsDialogLastEffect = cfg.readEntry (kpSettingMoreEffectsLastEffect, 0);
     kpToolEnvironment::drawAntiAliased = cfg.readEntry(kpSettingDrawAntiAliased, true);
 
@@ -218,7 +219,6 @@ void kpMainWindow::init ()
     setupActions ();
     createStatusBar ();
     createGUI ();
-    // This is where the Ribbon setup code goes
 
     createColorBox ();
 
@@ -260,6 +260,7 @@ void kpMainWindow::init ()
     auto rwidg = new SARibbonWidget(container);
     rwidg->setRibbonTheme(SARibbonTheme::RibbonThemeOffice2016Blue);
     d->ribbon = rwidg->ribbonBar();
+    d->ribbon->setVisible(d->configShowRibbon);
     setupRibbon();
     vbox->addWidget(rwidg);
     // setMenuWidget(ribbon);    // https://doc.qt.io/qt-6/qmainwindow.html#setMenuWidget

--- a/mainWindow/kpMainWindow.cpp
+++ b/mainWindow/kpMainWindow.cpp
@@ -34,6 +34,7 @@
 #include "environments/tools/kpToolEnvironment.h"
 #include "widgets/kpColorCells.h"
 #include "widgets/toolbars/kpColorToolBar.h"
+#include "widgets/kpColorPalette.h"
 #include "commands/kpCommandHistory.h"
 #include "document/kpDocument.h"
 #include "environments/document/kpDocumentEnvironment.h"
@@ -478,7 +479,7 @@ kpColorToolBar *kpMainWindow::colorToolBar () const
 // public
 kpColorCells *kpMainWindow::colorCells () const
 {
-    return m_colorCells;
+    return d->colorPalette->colorCells();
 }
 
 //---------------------------------------------------------------------

--- a/mainWindow/kpMainWindow.cpp
+++ b/mainWindow/kpMainWindow.cpp
@@ -259,6 +259,7 @@ void kpMainWindow::init ()
     auto vbox = new QVBoxLayout(container);
 
     auto rwidg = new SARibbonWidget(container);
+    // rwidg->setRibbonTheme(SARibbonTheme::RibbonThemeOffice2016Blue);
     d->ribbon = rwidg->ribbonBar();
     setupRibbon();
     vbox->addWidget(rwidg);

--- a/mainWindow/kpMainWindow.cpp
+++ b/mainWindow/kpMainWindow.cpp
@@ -281,8 +281,6 @@ void kpMainWindow::init ()
     // (have to do this _after_ setAutoSaveSettings as that applies the default settings)
     if (d->configFirstTime)
     {
-      d->toolToolBar->setToolButtonStyle(Qt::ToolButtonIconOnly);
-
       KConfigGroup cfg(KSharedConfig::openConfig(), QStringLiteral(kpSettingsGroupGeneral));
 
       cfg.writeEntry(kpSettingFirstTime, d->configFirstTime = false);

--- a/mainWindow/kpMainWindow.h
+++ b/mainWindow/kpMainWindow.h
@@ -140,6 +140,10 @@ private Q_SLOTS:
     void slotDocumentRestored ();
 
 //
+// UI state
+//
+
+//
 // Ribbon
 //
 

--- a/mainWindow/kpMainWindow.h
+++ b/mainWindow/kpMainWindow.h
@@ -125,8 +125,6 @@ public:
     kpCommandEnvironment *commandEnvironment ();
 
 private:
-    kpColorCells *m_colorCells;     // Usually placed within the ribbon
-
     void setupActions ();
     void enableDocumentActions (bool enable = true);
 
@@ -148,8 +146,14 @@ private Q_SLOTS:
 private:
     void setupRibbon();
 
+Q_SIGNALS:
+    void newPaletteTitle(QString title);
+
 private Q_SLOTS:
     void updatePaletteNameOrUrlLabel();
+
+    void slotFloatPalette();
+    void slotUnfloatPalette();
 
 //
 // Tools
@@ -701,6 +705,20 @@ public:
 
 private:
     struct kpMainWindowPrivate *d;
+};
+
+class PaletteToolWindow : public QMainWindow {
+    Q_OBJECT
+
+public:
+    PaletteToolWindow(QWidget *parent = nullptr);
+    virtual ~PaletteToolWindow();
+
+Q_SIGNALS:
+    void aboutToClose();
+
+protected:
+    virtual void closeEvent(QCloseEvent *event) override;
 };
 
 #endif  // KP_MAIN_WINDOW_H

--- a/mainWindow/kpMainWindow.h
+++ b/mainWindow/kpMainWindow.h
@@ -140,7 +140,7 @@ private Q_SLOTS:
     void slotDocumentRestored ();
 
 //
-// UI state
+// UI state (so that the source of truth is stored centrally and not inside a widget)
 //
 
 //
@@ -644,6 +644,7 @@ private Q_SLOTS:
 
     void slotEnableSettingsShowPath ();
     void slotShowPathToggled ();
+    void slotShowRibbonToggled(bool on);
     void slotDrawAntiAliasedToggled(bool on);
 
     void slotKeyBindings ();

--- a/mainWindow/kpMainWindow.h
+++ b/mainWindow/kpMainWindow.h
@@ -34,6 +34,9 @@
 
 #include <kxmlguiwindow.h>
 
+#include <SARibbonBar/SARibbonBar.h>
+#include <SARibbonBar/SARibbonWidget.h>
+
 #include "kpDefs.h"
 #include "pixmapfx/kpPixmapFX.h"
 #include "imagelib/kpImage.h"
@@ -136,6 +139,12 @@ private Q_SLOTS:
     void slotUpdateCaption ();
     void slotDocumentRestored ();
 
+//
+// Ribbon
+//
+
+private:
+    void setupRibbon();
 
 //
 // Tools

--- a/mainWindow/kpMainWindow.h
+++ b/mainWindow/kpMainWindow.h
@@ -125,6 +125,8 @@ public:
     kpCommandEnvironment *commandEnvironment ();
 
 private:
+    kpColorCells *m_colorCells;     // Usually placed within the ribbon
+
     void setupActions ();
     void enableDocumentActions (bool enable = true);
 
@@ -145,6 +147,9 @@ private Q_SLOTS:
 
 private:
     void setupRibbon();
+
+private Q_SLOTS:
+    void updatePaletteNameOrUrlLabel();
 
 //
 // Tools

--- a/mainWindow/kpMainWindowPrivate.h
+++ b/mainWindow/kpMainWindowPrivate.h
@@ -39,9 +39,11 @@
 class QAction;
 class QActionGroup;
 class QLabel;
+class QVBoxLayout;
 
 class SARibbonBar;
 class SARibbonContextCategory;
+class SARibbonPannel;
 class KSelectAction;
 class KToggleAction;
 class KSqueezedTextLabel;
@@ -59,6 +61,7 @@ class kpThumbnail;
 class kpThumbnailView;
 class kpDocument;
 class kpViewManager;
+class kpColorPalette;
 class kpColorToolBar;
 class kpToolToolBar;
 class kpCommandHistory;
@@ -274,6 +277,10 @@ struct kpMainWindowPrivate
   kpToolToolBar *toolToolBar;
   kpCommandHistory *commandHistory;
 
+  SARibbonPannel *pnPalette;
+  kpColorPalette *colorPalette;         // Because there is no easy way to have 2 palette widgets at once, this widget is physically transplanted from the ribbon to the floating window when that is requested (and vice versa when destroyed).
+  QVBoxLayout    *colorPaletteContainer;
+
   bool configFirstTime;
   bool configShowGrid;
   bool configShowPath;
@@ -449,6 +456,5 @@ struct kpMainWindowPrivate
   QString textOldFontFamily;
   int textOldFontSize;
 };
-
 
 #endif  // kpMainWindowPrivate_H

--- a/mainWindow/kpMainWindowPrivate.h
+++ b/mainWindow/kpMainWindowPrivate.h
@@ -213,6 +213,7 @@ struct kpMainWindowPrivate
       actionInvertColors(nullptr),
       actionClear(nullptr),
 
+      bgroupOpaqueOrTransparent(nullptr),
       actionDrawOpaque(nullptr),
       actionDrawColorSimilarity(nullptr),
 
@@ -392,6 +393,7 @@ struct kpMainWindowPrivate
 
   // Implemented in kpMainWindow_Tools.cpp, not kpImageWindow_Image.cpp
   // since they're really setting tool options.
+  QButtonGroup  *bgroupOpaqueOrTransparent;
   KToggleAction *actionDrawOpaque;
   QAction *actionDrawColorSimilarity;
 

--- a/mainWindow/kpMainWindowPrivate.h
+++ b/mainWindow/kpMainWindowPrivate.h
@@ -41,6 +41,7 @@ class QActionGroup;
 class QLabel;
 
 class SARibbonBar;
+class SARibbonContextCategory;
 class KSelectAction;
 class KToggleAction;
 class KSqueezedTextLabel;
@@ -73,6 +74,7 @@ struct kpMainWindowPrivate
       scrollView(nullptr),
       mainView(nullptr),
       ribbon(nullptr),
+      ribTextTools(nullptr),
       thumbnail(nullptr),
       thumbnailView(nullptr),
       document(nullptr),
@@ -262,6 +264,7 @@ struct kpMainWindowPrivate
   kpViewScrollableContainer *scrollView;
   kpZoomedView *mainView;
   SARibbonBar *ribbon;
+  SARibbonContextCategory *ribTextTools;
   kpThumbnail *thumbnail;
   kpThumbnailView *thumbnailView;
   kpDocument *document;

--- a/mainWindow/kpMainWindowPrivate.h
+++ b/mainWindow/kpMainWindowPrivate.h
@@ -40,6 +40,7 @@ class QAction;
 class QActionGroup;
 class QLabel;
 
+class SARibbonBar;
 class KSelectAction;
 class KToggleAction;
 class KSqueezedTextLabel;
@@ -71,6 +72,7 @@ struct kpMainWindowPrivate
     : isFullyConstructed(false),
       scrollView(nullptr),
       mainView(nullptr),
+      ribbon(nullptr),
       thumbnail(nullptr),
       thumbnailView(nullptr),
       document(nullptr),
@@ -259,6 +261,7 @@ struct kpMainWindowPrivate
 
   kpViewScrollableContainer *scrollView;
   kpZoomedView *mainView;
+  SARibbonBar *ribbon;
   kpThumbnail *thumbnail;
   kpThumbnailView *thumbnailView;
   kpDocument *document;

--- a/mainWindow/kpMainWindowPrivate.h
+++ b/mainWindow/kpMainWindowPrivate.h
@@ -413,6 +413,7 @@ struct kpMainWindowPrivate
 
   QAction *actionColorsAppendRow;
   QAction *actionColorsDeleteRow;
+  QAction *actionColorsSwap;
 
   //
   // Settings Menu

--- a/mainWindow/kpMainWindowPrivate.h
+++ b/mainWindow/kpMainWindowPrivate.h
@@ -286,6 +286,7 @@ struct kpMainWindowPrivate
   bool configFirstTime;
   bool configShowGrid;
   bool configShowPath;
+  bool configShowRibbon;
 
   bool configThumbnailShown;
   QRect configThumbnailGeometry;

--- a/mainWindow/kpMainWindowPrivate.h
+++ b/mainWindow/kpMainWindowPrivate.h
@@ -42,6 +42,7 @@ class QLabel;
 class QVBoxLayout;
 
 class SARibbonBar;
+class SARibbonCategory;
 class SARibbonContextCategory;
 class SARibbonPannel;
 class KSelectAction;
@@ -269,6 +270,7 @@ struct kpMainWindowPrivate
   kpZoomedView *mainView;
   SARibbonBar *ribbon;
   SARibbonContextCategory *ribTextTools;
+  SARibbonCategory *ribbonPgHome;
   kpThumbnail *thumbnail;
   kpThumbnailView *thumbnailView;
   kpDocument *document;
@@ -310,6 +312,7 @@ struct kpMainWindowPrivate
   kpToolText *toolText;
 
   QList <kpTool *> tools;
+  QList <kpTool *> toolsExclude;  // Exclude these tools in the above list from the Tools pannel (they are activated from elsewhere.)
   int lastToolNumber;
 
   bool toolActionsEnabled;

--- a/mainWindow/kpMainWindowPrivate.h
+++ b/mainWindow/kpMainWindowPrivate.h
@@ -52,6 +52,7 @@ class KRecentFilesAction;
 class KFontAction;
 class KFontSizeAction;
 class KToggleFullScreenAction;
+class KActionCollection;
 class kpCommandEnvironment;
 class kpDocumentEnvironment;
 class kpToolSelectionEnvironment;
@@ -217,7 +218,6 @@ struct kpMainWindowPrivate
       actionInvertColors(nullptr),
       actionClear(nullptr),
 
-      bgroupOpaqueOrTransparent(nullptr),
       actionDrawOpaque(nullptr),
       actionDrawColorSimilarity(nullptr),
 
@@ -332,6 +332,8 @@ struct kpMainWindowPrivate
 
   bool configOpenImagesInSameWindow, configPrintImageCenteredOnPage;
 
+  KActionCollection *fileActions;
+
   QAction *actionNew, *actionOpen;
   KRecentFilesAction *actionOpenRecent;
   QAction *actionScan, *actionScreenshot, *actionProperties,
@@ -403,7 +405,6 @@ struct kpMainWindowPrivate
 
   // Implemented in kpMainWindow_Tools.cpp, not kpImageWindow_Image.cpp
   // since they're really setting tool options.
-  QButtonGroup  *bgroupOpaqueOrTransparent;
   KToggleAction *actionDrawOpaque;
   QAction *actionDrawColorSimilarity;
 

--- a/mainWindow/kpMainWindow_Colors.cpp
+++ b/mainWindow/kpMainWindow_Colors.cpp
@@ -144,9 +144,6 @@ void kpMainWindow::createColorBox ()
 
     // (needed for QMainWindow::saveState())
     d->colorToolBar->setObjectName ( QStringLiteral("Color Box" ));
-
-    connect (colorCells (), &kpColorCells::rowCountChanged,
-             this, &kpMainWindow::slotUpdateColorsDeleteRowActionEnabled);
 }
 
 //---------------------------------------------------------------------
@@ -526,8 +523,7 @@ void kpMainWindow::slotColorsAppendRow ()
     // Call just in case.
     toolEndShape ();
 
-    kpColorCells *colorCells = d->colorToolBar->colorCells ();
-    colorCells->appendRow ();
+    m_colorCells->appendRow ();
 }
 
 //---------------------------------------------------------------------
@@ -538,6 +534,5 @@ void kpMainWindow::slotColorsDeleteRow ()
     // Call just in case.
     toolEndShape ();
 
-    kpColorCells *colorCells = d->colorToolBar->colorCells ();
-    colorCells->deleteLastRow ();
+    m_colorCells->deleteLastRow ();
 }

--- a/mainWindow/kpMainWindow_Colors.cpp
+++ b/mainWindow/kpMainWindow_Colors.cpp
@@ -28,10 +28,12 @@
 #include "kpMainWindow.h"
 #include "kpMainWindowPrivate.h"
 
+#include "tools/kpTool.h"
 #include "widgets/kpColorCells.h"
 #include "lgpl/generic/kpColorCollection.h"
 #include "lgpl/generic/kpUrlFormatter.h"
 #include "widgets/toolbars/kpColorToolBar.h"
+#include "widgets/toolbars/kpToolToolBar.h"
 
 #include <KActionCollection>
 #include <KMessageBox>
@@ -109,6 +111,13 @@ void kpMainWindow::setupColorsMenuActions ()
     d->actionColorsDeleteRow->setText (i18nc ("@item:inmenu colors", "Delete Last Row"));
     connect (d->actionColorsDeleteRow, &QAction::triggered,
              this, &kpMainWindow::slotColorsDeleteRow);
+
+    d->actionColorsSwap = ac->addAction (QStringLiteral("colors_swap"));
+    d->actionColorsSwap->setText (i18nc ("@item:inmenu colors", "Swap colours"));
+    connect (d->actionColorsSwap, &QAction::triggered, this, [&]() {
+        // if (d->toolToolBar->tool())
+            // d->toolToolBar->tool()->slotColorsSwappedInternal();
+    });
 
 
     enableColorsMenuDocumentActions (false);

--- a/mainWindow/kpMainWindow_Colors.cpp
+++ b/mainWindow/kpMainWindow_Colors.cpp
@@ -523,7 +523,7 @@ void kpMainWindow::slotColorsAppendRow ()
     // Call just in case.
     toolEndShape ();
 
-    m_colorCells->appendRow ();
+    colorCells()->appendRow ();
 }
 
 //---------------------------------------------------------------------
@@ -534,5 +534,5 @@ void kpMainWindow::slotColorsDeleteRow ()
     // Call just in case.
     toolEndShape ();
 
-    m_colorCells->deleteLastRow ();
+    colorCells()->deleteLastRow ();
 }

--- a/mainWindow/kpMainWindow_Colors.cpp
+++ b/mainWindow/kpMainWindow_Colors.cpp
@@ -85,38 +85,50 @@ void kpMainWindow::setupColorsMenuActions ()
 
     d->actionColorsOpen = ac->addAction (QStringLiteral("colors_open"));
     d->actionColorsOpen->setText (i18nc ("@item:inmenu colors", "&Open..."));
+    d->actionColorsOpen->setIcon(QIcon::fromTheme(QLatin1String("document-open")));
     connect (d->actionColorsOpen, &QAction::triggered, this, &kpMainWindow::slotColorsOpen);
 
     d->actionColorsReload = ac->addAction (QStringLiteral("colors_reload"));
     d->actionColorsReload->setText (i18nc ("@item:inmenu colors", "Reloa&d"));
+    d->actionColorsReload->setIcon(QIcon::fromTheme(QLatin1String("view-refresh")));
     connect (d->actionColorsReload, &QAction::triggered,
              this, &kpMainWindow::slotColorsReload);
 
     d->actionColorsSave = ac->addAction (QStringLiteral("colors_save"));
+    d->actionColorsSave->setIcon(QIcon::fromTheme(QLatin1String("document-save")));
     d->actionColorsSave->setText (i18nc ("@item:inmenu colors", "&Save"));
     connect (d->actionColorsSave, &QAction::triggered,
              this, &kpMainWindow::slotColorsSave);
 
     d->actionColorsSaveAs = ac->addAction (QStringLiteral("colors_save_as"));
     d->actionColorsSaveAs->setText (i18nc ("@item:inmenu colors", "Save &As..."));
+    d->actionColorsSaveAs->setIcon(QIcon::fromTheme(QLatin1String("document-save-as")));
     connect (d->actionColorsSaveAs, &QAction::triggered,
              this, &kpMainWindow::slotColorsSaveAs);
 
     d->actionColorsAppendRow = ac->addAction (QStringLiteral("colors_append_row"));
     d->actionColorsAppendRow->setText (i18nc ("@item:inmenu colors", "Add Row"));
+    d->actionColorsAppendRow->setIcon(QIcon::fromTheme(QLatin1String("list-add")));
     connect (d->actionColorsAppendRow, &QAction::triggered,
              this, &kpMainWindow::slotColorsAppendRow);
 
     d->actionColorsDeleteRow = ac->addAction (QStringLiteral("colors_delete_row"));
     d->actionColorsDeleteRow->setText (i18nc ("@item:inmenu colors", "Delete Last Row"));
+    d->actionColorsDeleteRow->setIcon(QIcon::fromTheme(QLatin1String("list-remove")));
     connect (d->actionColorsDeleteRow, &QAction::triggered,
              this, &kpMainWindow::slotColorsDeleteRow);
 
-    d->actionColorsSwap = ac->addAction (QStringLiteral("colors_swap"));
-    d->actionColorsSwap->setText (i18nc ("@item:inmenu colors", "Swap colours"));
-    connect (d->actionColorsSwap, &QAction::triggered, this, [&]() {
-        // if (d->toolToolBar->tool())
-            // d->toolToolBar->tool()->slotColorsSwappedInternal();
+    d->actionColorsSwap = ac->addAction(QStringLiteral("colors_swap"));
+    d->actionColorsSwap->setText(i18nc("@item:inmenu colors", "Swap Colours"));
+    d->actionColorsSwap->setIcon(QPixmap(QLatin1String(":/icons/colorbutton_swap_16x16")));
+    connect (d->actionColorsSwap, &QAction::triggered, [&]() {
+        auto newFg = d->colorToolBar->backgroundColor();
+        auto newBg = d->colorToolBar->foregroundColor();
+
+        d->colorToolBar->setForegroundColor(newFg);     // colorToolBar would have done this itself if the `colorsSwapped` was originating from inside of it.
+        d->colorToolBar->setBackgroundColor(newBg);
+
+        Q_EMIT d->colorToolBar->colorsSwapped(newFg, newBg);
     });
 
 

--- a/mainWindow/kpMainWindow_Edit.cpp
+++ b/mainWindow/kpMainWindow_Edit.cpp
@@ -42,6 +42,7 @@
 #include <KMessageBox>
 #include <KStandardAction>
 #include <KActionCollection>
+#include <KToolBarPopupAction>
 #include <KXMLGUIFactory>
 #include <KLocalizedString>
 
@@ -81,6 +82,8 @@ void kpMainWindow::setupEditMenuActions ()
     // Undo/Redo
     // CONFIG: Need GUI for config history size.
     d->commandHistory = new kpCommandHistory (true/*read config*/, this);
+    d->actionUndo = d->commandHistory->actionUndo();
+    d->actionRedo = d->commandHistory->actionRedo();
 
     if (d->configFirstTime)
     {

--- a/mainWindow/kpMainWindow_File.cpp
+++ b/mainWindow/kpMainWindow_File.cpp
@@ -85,7 +85,7 @@ void kpMainWindow::setupFileMenuActions ()
 #if DEBUG_KP_MAIN_WINDOW
     qCDebug(kpLogMainWindow) << "kpMainWindow::setupFileMenuActions()";
 #endif
-    KActionCollection *ac = actionCollection ();
+    KActionCollection *ac = d->fileActions = actionCollection ();
 
     d->actionNew = KStandardAction::openNew (this, SLOT (slotNew()), ac);
     d->actionOpen = KStandardAction::open (this, SLOT (slotOpen()), ac);

--- a/mainWindow/kpMainWindow_Image.cpp
+++ b/mainWindow/kpMainWindow_Image.cpp
@@ -131,11 +131,13 @@ void kpMainWindow::setupImageMenuActions ()
 
     d->actionFlip = ac->addAction (QStringLiteral("image_flip"));
     d->actionFlip->setText (i18n ("&Flip (upside down)"));
+    d->actionFlip->setIcon(QIcon::fromTheme(QStringLiteral("object-flip-vertical")));
     connect (d->actionFlip, &QAction::triggered, this, &kpMainWindow::slotFlip);
     ac->setDefaultShortcut (d->actionFlip, Qt::CTRL | Qt::Key_F);
 
     d->actionMirror = ac->addAction (QStringLiteral("image_mirror"));
     d->actionMirror->setText (i18n ("Mirror (horizontally)"));
+    d->actionMirror->setIcon(QIcon::fromTheme(QStringLiteral("object-flip-horizontal")));
     connect (d->actionMirror, &QAction::triggered, this, &kpMainWindow::slotMirror);
     //ac->setDefaultShortcut (d->actionMirror, Qt::CTRL | Qt::Key_M);
 
@@ -159,16 +161,17 @@ void kpMainWindow::setupImageMenuActions ()
 
     d->actionSkew = ac->addAction (QStringLiteral("image_skew"));
     d->actionSkew->setText (i18n ("S&kew..."));
+    d->actionSkew->setIcon(QPixmap(QStringLiteral(":/icons/image_skew_horizontal")));
     connect (d->actionSkew, &QAction::triggered, this, &kpMainWindow::slotSkew);
     ac->setDefaultShortcut (d->actionSkew, Qt::CTRL | Qt::Key_K);
 
     d->actionConvertToBlackAndWhite = ac->addAction (QStringLiteral("image_convert_to_black_and_white"));
-    d->actionConvertToBlackAndWhite->setText (i18n ("Reduce to Mo&nochrome (Dithered)"));
+    d->actionConvertToBlackAndWhite->setText (i18n ("Mo&nochrome (Dithered)"));
     connect (d->actionConvertToBlackAndWhite, &QAction::triggered,
              this, &kpMainWindow::slotConvertToBlackAndWhite);
 
     d->actionConvertToGrayscale = ac->addAction (QStringLiteral("image_convert_to_grayscale"));
-    d->actionConvertToGrayscale->setText (i18n ("Reduce to &Grayscale"));
+    d->actionConvertToGrayscale->setText (i18n ("&Grayscale"));
     connect (d->actionConvertToGrayscale, &QAction::triggered, this, &kpMainWindow::slotConvertToGrayscale);
 
     d->actionInvertColors = ac->addAction (QStringLiteral("image_invert_colors"));

--- a/mainWindow/kpMainWindow_Ribbon.cpp
+++ b/mainWindow/kpMainWindow_Ribbon.cpp
@@ -2,6 +2,7 @@
 #include "kpMainWindowPrivate.h"
 #include "tools/kpTool.h"
 #include "tools/selection/text/kpToolText.h"
+#include "widgets/toolbars/kpColorToolBar.h"
 #include "widgets/colorSimilarity/kpColorSimilarityToolBarItem.h"
 #include "kpLogCategories.h"
 
@@ -164,23 +165,31 @@ void kpMainWindow::setupRibbon()
             //
             
             {
-                SARibbonColorToolButton* colorButton = new SARibbonColorToolButton(pn);
-                // colorButton->setColor(defaultColor);
-                SAColorMenu *men = colorButton->setupStandardColorMenu();
-                colorButton->setButtonType(SARibbonToolButton::LargeButton);
-                colorButton->setColorStyle(SARibbonColorToolButton::ColorFillToIcon);
-                colorButton->setText(QLatin1String("Foreground"));
-                pn->addLargeWidget(colorButton);
-            }
+                auto fgButton = new SARibbonColorToolButton(pn);
+                auto bgButton = new SARibbonColorToolButton(pn);
+                SAColorMenu *fgMenu = fgButton->setupStandardColorMenu();
+                SAColorMenu *bgMenu = bgButton->setupStandardColorMenu();
+                fgButton->setButtonType(SARibbonToolButton::LargeButton);
+                bgButton->setButtonType(SARibbonToolButton::LargeButton);
+                fgButton->setColorStyle(SARibbonColorToolButton::ColorFillToIcon);
+                bgButton->setColorStyle(SARibbonColorToolButton::ColorFillToIcon);
+                fgButton->setText(QLatin1String("Foreground"));
+                bgButton->setText(QLatin1String("Background"));
+                pn->addLargeWidget(fgButton);
+                pn->addLargeWidget(bgButton);
 
-            {
-                SARibbonColorToolButton* colorButton = new SARibbonColorToolButton(pn);
-                // colorButton->setColor(defaultColor);
-                SAColorMenu *men = colorButton->setupStandardColorMenu();
-                colorButton->setButtonType(SARibbonToolButton::LargeButton);
-                colorButton->setColorStyle(SARibbonColorToolButton::ColorFillToIcon);
-                colorButton->setText(QLatin1String("Background"));
-                pn->addLargeWidget(colorButton);
+                connect(fgButton, &SARibbonColorToolButton::colorChanged, [&](const QColor& color) {
+                    d->colorToolBar->setForegroundColor(kpColor(color.rgba()));
+                });
+                connect(bgButton, &SARibbonColorToolButton::colorChanged, [&](const QColor& color) {
+                    d->colorToolBar->setBackgroundColor(kpColor(color.rgba()));
+                });
+                connect(d->colorToolBar, &kpColorToolBar::foregroundColorChanged, [&, fgButton](const kpColor& color) {
+                    fgButton->setColor(color.isTransparent() ? QColor(/*invalid*/) : color.toQColor());
+                });
+                connect(d->colorToolBar, &kpColorToolBar::backgroundColorChanged, [&, bgButton](const kpColor& color) {
+                    bgButton->setColor(color.isTransparent() ? QColor(/*invalid*/) : color.toQColor());
+                });
             }
 
             pn->addSmallAction(d->actionColorsAppendRow);

--- a/mainWindow/kpMainWindow_Ribbon.cpp
+++ b/mainWindow/kpMainWindow_Ribbon.cpp
@@ -1,0 +1,115 @@
+#include "mainWindow/kpMainWindow.h"
+#include "kpMainWindowPrivate.h"
+#include "kpLogCategories.h"
+
+#include <SARibbonBar/SARibbonCategory.h>
+#include <SARibbonBar/SARibbonPannel.h>
+#include <SARibbonBar/SARibbonMenu.h>
+
+#include <KStandardAction>
+#include <KToggleAction>
+
+#include <QCheckBox>
+#include <QString>
+
+static QAction* createAction(QMainWindow *win, const char *text, const char *iconurl)
+{
+    QAction* act = new QAction(win);
+    act->setText(QLatin1String(text));
+    act->setIcon(QIcon(QLatin1String(iconurl)));
+    act->setObjectName(QLatin1String(text));
+    win->connect(act, &QAction::triggered, win, [ win, act ]() {
+        // InnerWidget* w = qobject_cast< InnerWidget* >(widget());
+        // if (w) {
+        //     w->appendText(QString("action(%1) triggered").arg(act->text()));
+        // }
+    });
+    return act;
+}
+
+class MySARibbonPannel : public SARibbonPannel
+{
+public:
+    void addAction(KToggleAction *action, SARibbonPannelItem::RowProportion rp);
+};
+
+void MySARibbonPannel::addAction(KToggleAction *kAction, SARibbonPannelItem::RowProportion rp)
+{
+    auto checkbox = new QCheckBox();
+
+    checkbox->setText(kAction->text());
+    checkbox->setToolTip(kAction->toolTip() + (kAction->shortcut().isEmpty() ? QLatin1String("") : QLatin1String(" (%1)").arg(kAction->shortcut().toString())));
+    checkbox->setWhatsThis(kAction->whatsThis());
+    // checkbox->addAction(kAction);
+
+    QWidgetAction *wAction = (QWidgetAction *) this->addWidget(checkbox, rp);   // Check the code. It just gets casted down
+
+    // Bind checked state       // TODO: QT6 use QBindable
+    checkbox->setChecked(kAction->isChecked());
+    QObject::connect(kAction, &QAction::toggled, [=]() {
+        checkbox->setChecked(kAction->isChecked());
+    });
+    QObject::connect(checkbox, &QCheckBox::clicked, [kAction, checkbox]() {
+        kAction->trigger();
+    });
+
+    // Bind sensitivity
+    wAction->setEnabled(kAction->isEnabled());  // This doesnt work because the Panel wraps the widget in a QWidgetAction
+    QObject::connect(kAction, &QAction::changed, checkbox, [wAction, kAction]() {
+        wAction->setEnabled(kAction->isEnabled());
+    });
+}
+
+void kpMainWindow::setupRibbon()
+{
+    d->ribbon->setTitleVisible(false);
+    d->ribbon->setRibbonStyle(SARibbonBar::RibbonStyleCompactThreeRow);
+    d->ribbon->setApplicationButton(nullptr);
+
+
+    SARibbonCategory* page1 = new SARibbonCategory();
+    page1->setCategoryName(QLatin1String("page1"));
+    SARibbonPannel* pannel1 = new SARibbonPannel(QLatin1String("pannel1"), page1);
+    page1->addPannel(pannel1);
+    QAction* act = createAction(this, "  save  ", ":/icon/icon/save.svg");
+    act->setIconText(QLatin1String("  save  "));
+    pannel1->addLargeAction(act);
+    pannel1->addLargeAction(createAction(this, "open", ":/icon/icon/folder-star.svg"));
+    pannel1->addSmallAction(createAction(this, "action1", ":/icon/icon/action.svg"));
+    pannel1->addSmallAction(createAction(this, "action2", ":/icon/icon/action2.svg"));
+    SARibbonPannel* pannel2 = new SARibbonPannel(QLatin1String("pannel2"), page1);
+    page1->addPannel(pannel2);
+    pannel2->addLargeAction(createAction(this, "setting", ":/icon/icon/customize0.svg"));
+    pannel2->addLargeAction(createAction(this, "windowsflag", ":/icon/icon/windowsflag-normal.svg"));
+    d->ribbon->addCategoryPage(page1);
+
+    SARibbonCategory* pgView = new SARibbonCategory();
+    pgView->setCategoryName(QLatin1String("View"));
+        SARibbonPannel* pnZoom = new SARibbonPannel(QLatin1String("Zoom"), pgView);
+        pgView->addPannel(pnZoom);
+        pnZoom->addLargeAction(d->actionZoomIn);
+        pnZoom->addLargeAction(d->actionZoomOut);
+        pnZoom->addSmallAction(d->actionActualSize);
+
+        SARibbonMenu* fitMenu = new SARibbonMenu(this);
+        fitMenu->addAction(d->actionFitToPage);
+        fitMenu->addAction(d->actionFitToWidth);
+        fitMenu->addAction(d->actionFitToHeight);
+        auto act2 = createAction(this, "Fit to...", nullptr);
+        act2->setIcon(d->actionFitToPage->icon());
+        act2->setMenu(fitMenu);
+        pnZoom->addSmallAction(act2, QToolButton::InstantPopup);
+
+        MySARibbonPannel* pnShow = (MySARibbonPannel*) new SARibbonPannel(QLatin1String("Show or hide"), pgView);
+        pgView->addPannel(pnShow);
+        pnShow->addAction((d->actionShowGrid), SARibbonPannelItem::Small);
+        pnShow->addAction((KStandardAction::showStatusbar(this, nullptr, this)), SARibbonPannelItem::Small);
+        pnShow->addLargeAction(d->actionFullScreen);
+
+        MySARibbonPannel* pnThumb = (MySARibbonPannel*) new SARibbonPannel(QLatin1String("Thumbnail"), pgView);
+        pgView->addPannel(pnThumb);
+        pnThumb->addLargeAction(d->actionShowThumbnail);
+        pnThumb->addAction((d->actionZoomedThumbnail), SARibbonPannelItem::Small);
+        pnThumb->addAction((d->actionShowThumbnailRectangle), SARibbonPannelItem::Small);
+    d->ribbon->addCategoryPage(pgView);
+}

--- a/mainWindow/kpMainWindow_Ribbon.cpp
+++ b/mainWindow/kpMainWindow_Ribbon.cpp
@@ -2,6 +2,8 @@
 #include "kpMainWindowPrivate.h"
 #include "tools/kpTool.h"
 #include "tools/selection/text/kpToolText.h"
+#include "widgets/kpColorCells.h"
+#include "widgets/kpColorPalette.h"
 #include "widgets/toolbars/kpColorToolBar.h"
 #include "widgets/colorSimilarity/kpColorSimilarityToolBarItem.h"
 #include "kpLogCategories.h"
@@ -159,9 +161,6 @@ void kpMainWindow::setupRibbon()
             SARibbonPannel* pn = new SARibbonPannel(QLatin1String("Colours"), pg);
             pg->addPannel(pn);
 
-            QAction* optAct = new QAction(this);
-            pn->setOptionAction(optAct);
-
             //
             
             {
@@ -197,6 +196,43 @@ void kpMainWindow::setupRibbon()
             pn->addSmallAction(d->actionColorsSwap);
         }
         {
+            SARibbonPannel* pn = new SARibbonPannel(QLatin1String(""), pg);
+            pg->addPannel(pn);
+
+            QAction* optAct = new QAction(this);
+            pn->setOptionAction(optAct);
+
+            {
+                auto colorPalette = new kpColorPalette (pn);
+
+                connect (colorPalette, &kpColorPalette::foregroundColorChanged, [&](const kpColor& color) {
+                    d->colorToolBar->setForegroundColor(color);
+                });
+
+                connect (colorPalette, &kpColorPalette::backgroundColorChanged, [&](const kpColor& color) {
+                    d->colorToolBar->setBackgroundColor(color);
+                });
+
+                m_colorCells = colorPalette->colorCells ();
+
+                connect (colorCells (), &kpColorCells::rowCountChanged,
+                    this, &kpMainWindow::slotUpdateColorsDeleteRowActionEnabled);
+
+                connect (colorCells (), &kpColorCells::isModifiedChanged,
+                    this, &kpMainWindow::updatePaletteNameOrUrlLabel);
+
+                connect (colorCells (), &kpColorCells::urlChanged,
+                    this, &kpMainWindow::updatePaletteNameOrUrlLabel);
+
+                connect (colorCells (), &kpColorCells::nameChanged,
+                    this, &kpMainWindow::updatePaletteNameOrUrlLabel);
+
+                updatePaletteNameOrUrlLabel ();
+
+                pn->addLargeWidget(colorPalette);
+            }
+        }
+        {
             SARibbonPannel* pn = new SARibbonPannel(QLatin1String("Palette"), pg);
             pg->addPannel(pn);
 
@@ -217,15 +253,15 @@ void kpMainWindow::setupRibbon()
             }
             pn->addSmallAction(d->actionColorsReload);
 
-            {
-                auto colorSimWidg = new kpColorSimilarityToolBarItem (pn);
-                // connect (
-                //     colorSimWidg,
-                //     &kpColorSimilarityToolBarItem::colorSimilarityChanged,
-                //     this, &kpColorToolBar::colorSimilarityChanged);
+            // {
+            //     auto colorSimWidg = new kpColorSimilarityToolBarItem (pn);
+            //     // connect (
+            //     //     colorSimWidg,
+            //     //     &kpColorSimilarityToolBarItem::colorSimilarityChanged,
+            //     //     this, &kpColorToolBar::colorSimilarityChanged);
 
-                pn->addLargeWidget(colorSimWidg);
-            }
+            //     pn->addLargeWidget(colorSimWidg);
+            // }
         }
     }
 
@@ -356,4 +392,55 @@ void kpMainWindow::setupRibbon()
         // pnClp2->addSmallAction(KStandardAction::create(KStandardAction::Paste, this, nullptr, this));
     d->ribbon->hideContextCategory(d->ribTextTools);
     
+}
+
+void kpMainWindow::updatePaletteNameOrUrlLabel()
+{
+    // QString name;
+
+    // kpColorCells *colorCells = colorPalette->colorCells ();
+    // if (!colorCells->url ().isEmpty ()) {
+    //     name = kpUrlFormatter::PrettyFilename (colorCells->url ());
+    // }
+    // else
+    // {
+    //     if (!colorCells->name ().isEmpty ()) {
+    //         name = colorCells->name ();
+    //     }
+    //     else {
+    //         name = i18n ("KolourPaint Defaults");
+    //     }
+    // }
+
+    // if (name.isEmpty ()) {
+    //     name = i18n ("Untitled");
+    // }
+
+
+    // KLocalizedString labelStr;
+
+    // if (!colorPalette->colorCells ()->isModified ())
+    // {
+    //     labelStr =
+    //         ki18nc ("Colors: name_or_url_of_color_palette",
+    //                 "Colors: %1")
+    //             .subs (name);
+    // }
+    // else
+    // {
+    //     labelStr =
+    //         ki18nc ("Colors: name_or_url_of_color_palette [modified]",
+    //                 "Colors: %1 [modified]")
+    //             .subs (name);
+    // }
+
+    // // Kill 2 birds with 1 stone:
+    // //
+    // // 1. Hide the windowTitle() when it's docked.
+    // // 2. Add a label containing the name of the open color palette.
+    // //
+    // // TODO: This currently hides the windowTitle() even when it's not docked,
+    // //       because we've abused it to show the name of open color palette
+    // //       instead.
+    // setWindowTitle (labelStr.toString ());
 }

--- a/mainWindow/kpMainWindow_Ribbon.cpp
+++ b/mainWindow/kpMainWindow_Ribbon.cpp
@@ -55,8 +55,9 @@ static QAction* createAction(QMainWindow *win, const char *text, const char *ico
 class MySARibbonPannel : public SARibbonPannel
 {
 public:
-    void addAction(KToggleAction *action, SARibbonPannelItem::RowProportion rp);
+    void addAction(KToggleAction *action, SARibbonPannelItem::RowProportion rp);    // This is an implementation specific to `KToggleAction` that creates a checkbox instead of a button
 };
+
 
 void MySARibbonPannel::addAction(KToggleAction *kAction, SARibbonPannelItem::RowProportion rp)
 {
@@ -142,9 +143,59 @@ void kpMainWindow::setupRibbon()
     pgColors->setCategoryName(QLatin1String("Colors"));
     d->ribbon->addCategoryPage(pgColors);
 
-    SARibbonCategory* pgImage = new SARibbonCategory();
-    pgImage->setCategoryName(QLatin1String("Image"));
-    d->ribbon->addCategoryPage(pgImage);
+    {
+        SARibbonCategory* pg = new SARibbonCategory();
+        pg->setCategoryName(QLatin1String("Image"));
+        d->ribbon->addCategoryPage(pg);
+
+        {
+            SARibbonPannel* pn = new SARibbonPannel(QLatin1String("Size"), pg);
+            pg->addPannel(pn);
+            pn->addLargeAction(d->actionResizeScale);
+            pn->addSmallAction(d->actionAutoCrop);
+        }
+        {
+            SARibbonPannel* pn = new SARibbonPannel(QLatin1String("Manipulate"), pg);
+            pg->addPannel(pn);
+
+            {
+                auto group = new SARibbonButtonGroupWidget(pnTools);
+                pn->addMediumWidget(group);
+
+                group->addAction(d->actionRotateLeft);
+                group->addAction(d->actionRotateRight);
+            }
+            {
+                auto group = new SARibbonButtonGroupWidget(pnTools);
+                pn->addMediumWidget(group);
+
+                group->addAction(d->actionMirror);
+                group->addAction(d->actionFlip);
+            }
+
+            pn->addLargeAction(d->actionRotate);
+            pn->addLargeAction(d->actionSkew);
+        }
+        {
+            SARibbonPannel* pn = new SARibbonPannel(QLatin1String("Image Effects"), pg);
+            pg->addPannel(pn);
+
+            pn->addSmallAction(d->actionInvertColors);
+            {
+                SARibbonMenu* menu = new SARibbonMenu(pn);
+                menu->addAction(d->actionConvertToGrayscale);
+                menu->addAction(d->actionConvertToBlackAndWhite);
+
+                auto act1 = createAction(this, "Reduce to", nullptr);
+                // act1->setIcon();
+                act1->setMenu(menu);
+
+                pn->addSmallAction(act1, QToolButton::InstantPopup);
+            }
+            pn->addSmallAction(d->actionBlur);
+            pn->addLargeAction(d->actionMoreEffects);
+        }
+    }
 
     SARibbonCategory* pgView = new SARibbonCategory();
     pgView->setCategoryName(QLatin1String("View"));

--- a/mainWindow/kpMainWindow_Ribbon.cpp
+++ b/mainWindow/kpMainWindow_Ribbon.cpp
@@ -98,6 +98,17 @@ void MySARibbonPannel::addAction(KToggleAction *kAction, SARibbonPannelItem::Row
     });
 }
 
+static QAction *getActionNamed(QList<QAction *> acts, QString name)
+{
+    for (auto *act : acts)
+    {
+        if (act->objectName() == name)
+            return act;
+    }
+
+    return nullptr;
+}
+
 void kpMainWindow::setupRibbon()
 {
     d->ribbon->setTitleVisible(false);
@@ -115,21 +126,8 @@ void kpMainWindow::setupRibbon()
 
     auto fileButton = new SARibbonApplicationButton(this);
     fileButton->setText(QLatin1String("&File"));
+    fileButton->setMenu(getActionNamed(menuBar()->actions(), QLatin1String("file"))->menu());
     d->ribbon->setApplicationButton(fileButton);
-
-    // auto fileButtonMenu = new SARibbonMenu(this);
-    // 
-    // for (auto *g : d->fileActions->actionGroups())
-    // {
-    //     for (auto *act : g->actions())
-    //         fileButtonMenu->addAction(act);
-    //     fileButtonMenu->addSeparator();
-    // }
-    // fileButtonMenu->addSeparator();
-    // for (auto *act : d->fileActions->actionsWithoutGroup())
-    //     fileButtonMenu->addAction(act);
-
-    fileButton->setMenu(menuBar()->actions()[0]->menu());
 
     /* Pages */
 
@@ -354,35 +352,71 @@ void kpMainWindow::setupRibbon()
         }
     }
 
-    SARibbonCategory* pgView = new SARibbonCategory();
-    pgView->setCategoryName(QLatin1String("View"));
-        SARibbonPannel* pnZoom = new SARibbonPannel(QLatin1String("Zoom"), pgView);
-        pgView->addPannel(pnZoom);
-        pnZoom->addLargeAction(d->actionZoomIn);
-        pnZoom->addLargeAction(d->actionZoomOut);
-        pnZoom->addSmallAction(d->actionActualSize);
+    {
+        SARibbonCategory* pgView = new SARibbonCategory();
+        pgView->setCategoryName(QLatin1String("View"));
+        d->ribbon->addCategoryPage(pgView);
 
-        SARibbonMenu* fitMenu = new SARibbonMenu(this);
-        fitMenu->addAction(d->actionFitToPage);
-        fitMenu->addAction(d->actionFitToWidth);
-        fitMenu->addAction(d->actionFitToHeight);
-        auto act2 = createAction(this, "Fit to...", nullptr);
-        act2->setIcon(d->actionFitToPage->icon());
-        act2->setMenu(fitMenu);
-        pnZoom->addSmallAction(act2, QToolButton::InstantPopup);
+        {
+            SARibbonPannel* pnZoom = new SARibbonPannel(QLatin1String("Zoom"), pgView);
+            pgView->addPannel(pnZoom);
 
-        MySARibbonPannel* pnShow = (MySARibbonPannel*) new SARibbonPannel(QLatin1String("Show or hide"), pgView);
-        pgView->addPannel(pnShow);
-        pnShow->addAction((d->actionShowGrid), SARibbonPannelItem::Small);
-        pnShow->addAction((KStandardAction::showStatusbar(this, nullptr, this)), SARibbonPannelItem::Small);
-        pnShow->addLargeAction(d->actionFullScreen);
+            pnZoom->addLargeAction(d->actionZoomIn);
+            pnZoom->addLargeAction(d->actionZoomOut);
+            pnZoom->addSmallAction(d->actionActualSize);
 
-        MySARibbonPannel* pnThumb = (MySARibbonPannel*) new SARibbonPannel(QLatin1String("Thumbnail"), pgView);
-        pgView->addPannel(pnThumb);
-        pnThumb->addLargeAction(d->actionShowThumbnail);
-        pnThumb->addAction((d->actionZoomedThumbnail), SARibbonPannelItem::Small);
-        pnThumb->addAction((d->actionShowThumbnailRectangle), SARibbonPannelItem::Small);
-    d->ribbon->addCategoryPage(pgView);
+            {
+                SARibbonMenu* fitMenu = new SARibbonMenu(this);
+                fitMenu->addAction(d->actionFitToPage);
+                fitMenu->addAction(d->actionFitToWidth);
+                fitMenu->addAction(d->actionFitToHeight);
+
+                auto act2 = createAction(this, "Fit to...", nullptr);
+                act2->setIcon(d->actionFitToPage->icon());
+                act2->setMenu(fitMenu);
+
+                pnZoom->addSmallAction(act2, QToolButton::InstantPopup);
+            }
+
+        }
+        {
+            MySARibbonPannel* pnShow = (MySARibbonPannel*) new SARibbonPannel(QLatin1String("Show or hide"), pgView);
+            pgView->addPannel(pnShow);
+            pnShow->addAction((d->actionShowGrid), SARibbonPannelItem::Small);
+            pnShow->addAction((KStandardAction::showStatusbar(this, nullptr, this)), SARibbonPannelItem::Small);
+            pnShow->addLargeAction(d->actionFullScreen);
+        }
+        {
+            MySARibbonPannel* pnThumb = (MySARibbonPannel*) new SARibbonPannel(QLatin1String("Thumbnail"), pgView);
+            pgView->addPannel(pnThumb);
+            pnThumb->addLargeAction(d->actionShowThumbnail);
+            pnThumb->addAction((d->actionZoomedThumbnail), SARibbonPannelItem::Small);
+            pnThumb->addAction((d->actionShowThumbnailRectangle), SARibbonPannelItem::Small);
+        }
+        {
+            MySARibbonPannel* pn = (MySARibbonPannel*) new SARibbonPannel(QLatin1String(/*"Settings"*/""), pgView);
+            pgView->addPannel(pn);
+
+            {
+                auto act = createAction(this, "Settings", nullptr);
+                act->setIcon(QIcon::fromTheme(QLatin1String("settings")));
+                act->setMenu(getActionNamed(menuBar()->actions(), QLatin1String("settings"))->menu());
+
+                pn->addLargeAction(act, QToolButton::InstantPopup);
+            }
+            {
+                auto act = createAction(this, "Help", nullptr);
+                act->setIcon(QIcon::fromTheme(QLatin1String("help")));
+                act->setMenu(getActionNamed(menuBar()->actions(), QLatin1String("help"))->menu());
+
+                pn->addLargeAction(act, QToolButton::InstantPopup);
+            }
+
+            // FIXME: This is supposed to be created automatically from its entry in kolourpaintui.rc but isn't for some reason.
+            auto settingsMenu = getActionNamed(menuBar()->actions(), QLatin1String("settings"))->menu();
+            settingsMenu->insertAction(actionCollection()->action(QLatin1String("settings_show_path")), actionCollection()->action(QLatin1String("settings_show_ribbon")));
+        }
+    }
 
     d->ribTextTools = d->ribbon->addContextCategory(QLatin1String("Text tools"), QColor(), 1);
     SARibbonCategory* pgText = d->ribTextTools->addCategoryPage(QLatin1String("Text"));

--- a/mainWindow/kpMainWindow_Ribbon.cpp
+++ b/mainWindow/kpMainWindow_Ribbon.cpp
@@ -262,16 +262,30 @@ void kpMainWindow::setupRibbon()
                 d->actionColorsSave->setMenu(menu);
             }
             pn->addSmallAction(d->actionColorsReload);
+        }
+        {
+            SARibbonPannel* pn = new SARibbonPannel(QLatin1String("Colour Similarity"), pg);
+            pg->addPannel(pn);
 
-            // {
-            //     auto colorSimWidg = new kpColorSimilarityToolBarItem (pn);
-            //     // connect (
-            //     //     colorSimWidg,
-            //     //     &kpColorSimilarityToolBarItem::colorSimilarityChanged,
-            //     //     this, &kpColorToolBar::colorSimilarityChanged);
+            auto colorSimWidg = new kpColorSimilarityToolBarItem (pn);
+            connect (
+                colorSimWidg,
+                &kpColorSimilarityToolBarItem::colorSimilarityChanged,
+                [&, colorSimWidg](double similarity, int processedSimilarity) {
+                    colorSimWidg->blockSignals(true);
+                    d->colorToolBar->setColorSimilarity(similarity);
+                    colorSimWidg->blockSignals(false);
+                }
+            );
+            connect(
+                d->colorToolBar,
+                &kpColorToolBar::colorSimilarityChanged,
+                [&, colorSimWidg](double similarity, int processedSimilarity) {
+                    colorSimWidg->setColorSimilarity(similarity);
+                }
+            );
 
-            //     pn->addLargeWidget(colorSimWidg);
-            // }
+            pn->addLargeWidget(colorSimWidg);
         }
     }
 

--- a/mainWindow/kpMainWindow_Ribbon.cpp
+++ b/mainWindow/kpMainWindow_Ribbon.cpp
@@ -7,6 +7,7 @@
 #include <SARibbonBar/SARibbonCategory.h>
 #include <SARibbonBar/SARibbonPannel.h>
 #include <SARibbonBar/SARibbonMenu.h>
+#include <SARibbonBar/SARibbonQuickAccessBar.h>
 #include <SARibbonBar/SARibbonButtonGroupWidget.h>
 
 #include <KStandardAction>
@@ -18,6 +19,7 @@
 #include <QButtonGroup>
 #include <QString>
 #include <QHBoxLayout>
+#include <QWidgetAction>
 
     // m_toolWidgets.append (m_toolWidgetBrush =
     //     new kpToolWidgetBrush (m_baseWidget, QStringLiteral("Tool Widget Brush")));
@@ -92,6 +94,11 @@ void kpMainWindow::setupRibbon()
     d->ribbon->setRibbonStyle(SARibbonBar::RibbonStyleCompactThreeRow);
     d->ribbon->setApplicationButton(nullptr);
 
+    d->ribbon->quickAccessBar()->addAction(d->actionSave);
+    d->ribbon->quickAccessBar()->addAction(d->actionUndo);
+    d->ribbon->quickAccessBar()->addAction(d->actionRedo);
+
+    /* Pages */
 
     SARibbonCategory* pgHome = new SARibbonCategory();
     pgHome->setCategoryName(QLatin1String("Home"));

--- a/mainWindow/kpMainWindow_Ribbon.cpp
+++ b/mainWindow/kpMainWindow_Ribbon.cpp
@@ -2,6 +2,7 @@
 #include "kpMainWindowPrivate.h"
 #include "tools/kpTool.h"
 #include "tools/selection/text/kpToolText.h"
+#include "widgets/colorSimilarity/kpColorSimilarityToolBarItem.h"
 #include "kpLogCategories.h"
 
 #include <SARibbonBar/SARibbonCategory.h>
@@ -9,6 +10,7 @@
 #include <SARibbonBar/SARibbonMenu.h>
 #include <SARibbonBar/SARibbonQuickAccessBar.h>
 #include <SARibbonBar/SARibbonButtonGroupWidget.h>
+#include <SARibbonBar/SARibbonColorToolButton.h>
 
 #include <KStandardAction>
 #include <KToggleAction>
@@ -95,6 +97,7 @@ void kpMainWindow::setupRibbon()
     d->ribbon->setApplicationButton(nullptr);
 
     d->ribbon->quickAccessBar()->addAction(d->actionSave);
+    d->ribbon->quickAccessBar()->addSeparator();
     d->ribbon->quickAccessBar()->addAction(d->actionUndo);
     d->ribbon->quickAccessBar()->addAction(d->actionRedo);
 
@@ -146,9 +149,76 @@ void kpMainWindow::setupRibbon()
 
     d->ribbon->addCategoryPage(pgHome);
 
-    SARibbonCategory* pgColors = new SARibbonCategory();
-    pgColors->setCategoryName(QLatin1String("Colors"));
-    d->ribbon->addCategoryPage(pgColors);
+    {
+        SARibbonCategory* pg = new SARibbonCategory();
+        pg->setCategoryName(QLatin1String("Colours"));
+        d->ribbon->addCategoryPage(pg);
+
+        {
+            SARibbonPannel* pn = new SARibbonPannel(QLatin1String("Colours"), pg);
+            pg->addPannel(pn);
+
+            QAction* optAct = new QAction(this);
+            pn->setOptionAction(optAct);
+
+            //
+            
+            {
+                SARibbonColorToolButton* colorButton = new SARibbonColorToolButton(pn);
+                // colorButton->setColor(defaultColor);
+                SAColorMenu *men = colorButton->setupStandardColorMenu();
+                colorButton->setButtonType(SARibbonToolButton::LargeButton);
+                colorButton->setColorStyle(SARibbonColorToolButton::ColorFillToIcon);
+                colorButton->setText(QLatin1String("Foreground"));
+                pn->addLargeWidget(colorButton);
+            }
+
+            {
+                SARibbonColorToolButton* colorButton = new SARibbonColorToolButton(pn);
+                // colorButton->setColor(defaultColor);
+                SAColorMenu *men = colorButton->setupStandardColorMenu();
+                colorButton->setButtonType(SARibbonToolButton::LargeButton);
+                colorButton->setColorStyle(SARibbonColorToolButton::ColorFillToIcon);
+                colorButton->setText(QLatin1String("Background"));
+                pn->addLargeWidget(colorButton);
+            }
+
+            pn->addSmallAction(d->actionColorsAppendRow);
+            pn->addSmallAction(d->actionColorsDeleteRow);
+            pn->addSmallAction(d->actionColorsSwap);
+        }
+        {
+            SARibbonPannel* pn = new SARibbonPannel(QLatin1String("Palette"), pg);
+            pg->addPannel(pn);
+
+            {
+                pn->addSmallAction(d->actionColorsOpen, QToolButton::MenuButtonPopup);
+
+                auto menu = new SARibbonMenu(pn);
+                menu->addAction(d->actionColorsDefault);
+                menu->addAction(d->actionColorsKDE);
+                d->actionColorsOpen->setMenu(menu);
+            }
+            {
+                pn->addSmallAction(d->actionColorsSave, QToolButton::MenuButtonPopup);
+
+                auto menu = new SARibbonMenu(pn);
+                menu->addAction(d->actionColorsSaveAs);
+                d->actionColorsSave->setMenu(menu);
+            }
+            pn->addSmallAction(d->actionColorsReload);
+
+            {
+                auto colorSimWidg = new kpColorSimilarityToolBarItem (pn);
+                // connect (
+                //     colorSimWidg,
+                //     &kpColorSimilarityToolBarItem::colorSimilarityChanged,
+                //     this, &kpColorToolBar::colorSimilarityChanged);
+
+                pn->addLargeWidget(colorSimWidg);
+            }
+        }
+    }
 
     {
         SARibbonCategory* pg = new SARibbonCategory();

--- a/mainWindow/kpMainWindow_Ribbon.cpp
+++ b/mainWindow/kpMainWindow_Ribbon.cpp
@@ -5,12 +5,16 @@
 #include <SARibbonBar/SARibbonCategory.h>
 #include <SARibbonBar/SARibbonPannel.h>
 #include <SARibbonBar/SARibbonMenu.h>
+#include <SARibbonBar/SARibbonButtonGroupWidget.h>
 
 #include <KStandardAction>
 #include <KToggleAction>
+#include <KFontSizeAction>
+#include <KFontAction>
 
 #include <QCheckBox>
 #include <QString>
+#include <QHBoxLayout>
 
 static QAction* createAction(QMainWindow *win, const char *text, const char *iconurl)
 {
@@ -112,4 +116,22 @@ void kpMainWindow::setupRibbon()
         pnThumb->addAction((d->actionZoomedThumbnail), SARibbonPannelItem::Small);
         pnThumb->addAction((d->actionShowThumbnailRectangle), SARibbonPannelItem::Small);
     d->ribbon->addCategoryPage(pgView);
+
+    d->ribTextTools = d->ribbon->addContextCategory(QLatin1String("Text tools"), QColor(), 1);
+    SARibbonCategory* pgText = d->ribTextTools->addCategoryPage(QLatin1String("Text"));
+        SARibbonPannel* pnFont = new SARibbonPannel(QLatin1String("Font"), pgText);
+        pgText->addPannel(pnFont);
+        pnFont->addMediumAction(static_cast<QAction*>(d->actionTextFontFamily));
+        auto hBox = new QWidget(this);
+        auto hLayout = new QHBoxLayout(hBox);
+            hLayout->addWidget(d->actionTextFontSize->requestWidget(hBox));
+            auto fontSettingsGrp = new SARibbonButtonGroupWidget(pnFont);
+                fontSettingsGrp->addAction(d->actionTextBold);
+                fontSettingsGrp->addAction(d->actionTextItalic);
+                fontSettingsGrp->addAction(d->actionTextUnderline);
+                fontSettingsGrp->addAction(d->actionTextStrikeThru);
+            hLayout->addWidget(fontSettingsGrp);
+        pnFont->addMediumWidget(hBox);
+    d->ribbon->hideContextCategory(d->ribTextTools);
+    
 }

--- a/mainWindow/kpMainWindow_Ribbon.cpp
+++ b/mainWindow/kpMainWindow_Ribbon.cpp
@@ -15,9 +15,13 @@
 #include <SARibbonBar/SARibbonQuickAccessBar.h>
 #include <SARibbonBar/SARibbonButtonGroupWidget.h>
 #include <SARibbonBar/SARibbonColorToolButton.h>
+#include <SARibbonBar/SARibbonApplicationButton.h>
+#include <SARibbonBar/SARibbonMenu.h>
+
 
 #include <KStandardAction>
 #include <KToggleAction>
+#include <KActionCollection>
 #include <KFontSizeAction>
 #include <KFontAction>
 
@@ -100,10 +104,32 @@ void kpMainWindow::setupRibbon()
     d->ribbon->setRibbonStyle(SARibbonBar::RibbonStyleCompactThreeRow);
     d->ribbon->setApplicationButton(nullptr);
 
+    /* Quick access bar */
+
     d->ribbon->quickAccessBar()->addAction(d->actionSave);
     d->ribbon->quickAccessBar()->addSeparator();
     d->ribbon->quickAccessBar()->addAction(d->actionUndo);
     d->ribbon->quickAccessBar()->addAction(d->actionRedo);
+
+    /* File menu */
+
+    auto fileButton = new SARibbonApplicationButton(this);
+    fileButton->setText(QLatin1String("&File"));
+    d->ribbon->setApplicationButton(fileButton);
+
+    // auto fileButtonMenu = new SARibbonMenu(this);
+    // 
+    // for (auto *g : d->fileActions->actionGroups())
+    // {
+    //     for (auto *act : g->actions())
+    //         fileButtonMenu->addAction(act);
+    //     fileButtonMenu->addSeparator();
+    // }
+    // fileButtonMenu->addSeparator();
+    // for (auto *act : d->fileActions->actionsWithoutGroup())
+    //     fileButtonMenu->addAction(act);
+
+    fileButton->setMenu(menuBar()->actions()[0]->menu());
 
     /* Pages */
 
@@ -379,26 +405,6 @@ void kpMainWindow::setupRibbon()
                 fontSettingsGrp->addAction(d->actionTextStrikeThru);
             hLayout->addWidget(fontSettingsGrp);
         pnFont->addMediumWidget(hBox);
-
-        SARibbonPannel* pnBg = new SARibbonPannel(QLatin1String("Background"), pgText);
-        pgText->addPannel(pnBg);
-            d->bgroupOpaqueOrTransparent = new QButtonGroup(pnBg);
-            d->bgroupOpaqueOrTransparent->setExclusive(true);
-            connect(d->bgroupOpaqueOrTransparent, &QButtonGroup::idToggled, this, &kpMainWindow::updateActionDrawOpaqueChecked);
-
-            auto tparencyOpaque = new QPushButton(QPixmap(QStringLiteral(":/icons/option_opaque")), QLatin1String("Opaque"), pnBg);
-            tparencyOpaque->setCheckable(true);
-            tparencyOpaque->setChecked(true);
-            d->bgroupOpaqueOrTransparent->addButton(tparencyOpaque, 0);
-            pnBg->addSmallWidget(tparencyOpaque);
-
-            auto tparencyTparent = new QPushButton(QPixmap(QStringLiteral(":/icons/option_transparent")), QLatin1String("Transparent"), pnBg);
-            tparencyTparent->setCheckable(true);
-            tparencyTparent->setChecked(true);
-            d->bgroupOpaqueOrTransparent->addButton(tparencyTparent, 1);
-            pnBg->addSmallWidget(tparencyTparent);
-        // Transparent / Opaque
-        // pnClp2->addSmallAction(KStandardAction::create(KStandardAction::Paste, this, nullptr, this));
     d->ribbon->hideContextCategory(d->ribTextTools);
     
 }

--- a/mainWindow/kpMainWindow_Ribbon.cpp
+++ b/mainWindow/kpMainWindow_Ribbon.cpp
@@ -107,7 +107,7 @@ void kpMainWindow::setupRibbon()
 
     /* Pages */
 
-    SARibbonCategory* pgHome = new SARibbonCategory();
+    SARibbonCategory* pgHome = d->ribbonPgHome =  new SARibbonCategory();
     pgHome->setCategoryName(QLatin1String("Home"));
         SARibbonPannel* pnClp = new SARibbonPannel(QLatin1String("Clipboard"), pgHome);
         pgHome->addPannel(pnClp);
@@ -135,21 +135,6 @@ void kpMainWindow::setupRibbon()
         pnSel->addSmallAction(d->actionSelectAll);
         pnSel->addSmallAction(d->actionDeselect);
         pnSel->addSmallAction(d->actionDelete);
-
-        SARibbonPannel* pnTools = new SARibbonPannel(QLatin1String("Tools"), pgHome);
-        pgHome->addPannel(pnTools);
-        auto toolsRow1 = new SARibbonButtonGroupWidget(pnTools);
-            toolsRow1->addAction(d->toolPen->action());
-            toolsRow1->addAction(d->toolLine->action());
-            toolsRow1->addAction(d->toolPolygon->action());
-            toolsRow1->addAction(d->toolText->action());
-        auto toolsRow2 = new SARibbonButtonGroupWidget(pnTools);
-            toolsRow2->addAction(d->toolFloodFill->action());
-            toolsRow2->addAction(d->toolEraser->action());
-            toolsRow2->addAction(d->toolColorPicker->action());
-            toolsRow2->addAction(d->toolZoom->action());
-        pnTools->addMediumWidget(toolsRow1);
-        pnTools->addMediumWidget(toolsRow2);
 
     d->ribbon->addCategoryPage(pgHome);
 
@@ -305,14 +290,14 @@ void kpMainWindow::setupRibbon()
             pg->addPannel(pn);
 
             {
-                auto group = new SARibbonButtonGroupWidget(pnTools);
+                auto group = new SARibbonButtonGroupWidget(pn);
                 pn->addMediumWidget(group);
 
                 group->addAction(d->actionRotateLeft);
                 group->addAction(d->actionRotateRight);
             }
             {
-                auto group = new SARibbonButtonGroupWidget(pnTools);
+                auto group = new SARibbonButtonGroupWidget(pn);
                 pn->addMediumWidget(group);
 
                 group->addAction(d->actionMirror);

--- a/mainWindow/kpMainWindow_Settings.cpp
+++ b/mainWindow/kpMainWindow_Settings.cpp
@@ -40,7 +40,9 @@
 
 #include "kpDefs.h"
 #include "document/kpDocument.h"
+#include "widgets/kpColorPalette.h"
 #include "widgets/toolbars/kpToolToolBar.h"
+#include "widgets/toolbars/kpColorToolBar.h"
 #include "environments/tools/kpToolEnvironment.h"
 
 //---------------------------------------------------------------------
@@ -67,7 +69,12 @@ void kpMainWindow::setupSettingsMenuActions ()
     connect (d->actionShowPath, &QAction::triggered, this, &kpMainWindow::slotShowPathToggled);
     slotEnableSettingsShowPath ();
 
-    auto *action = ac->add<KToggleAction>(QStringLiteral("settings_draw_antialiased"));
+    auto *action = ac->add<KToggleAction>(QStringLiteral("settings_show_ribbon"));
+    action->setText(i18n("Show &Ribbon"));
+    action->setChecked(d->configShowRibbon);
+    connect (action, &KToggleAction::triggered, this, &kpMainWindow::slotShowRibbonToggled);
+
+    action = ac->add<KToggleAction>(QStringLiteral("settings_draw_antialiased"));
     action->setText(i18n("Draw Anti-Aliased"));
     action->setChecked(kpToolEnvironment::drawAntiAliased);
     connect (action, &KToggleAction::triggered, this, &kpMainWindow::slotDrawAntiAliasedToggled);
@@ -127,6 +134,41 @@ void kpMainWindow::slotShowPathToggled ()
 
     cfg.writeEntry (kpSettingShowPath, d->configShowPath);
     cfg.sync ();
+}
+
+//---------------------------------------------------------------------
+
+void kpMainWindow::slotShowRibbonToggled(bool showRibbon)
+{
+    d->configShowRibbon = showRibbon;
+
+    KConfigGroup cfg(KSharedConfig::openConfig(), QStringLiteral(kpSettingsGroupGeneral));
+
+    cfg.writeEntry(kpSettingShowRibbon, d->configShowRibbon);
+    cfg.sync();
+
+    d->ribbon->setVisible(showRibbon);
+
+    menuBar()->setVisible(!showRibbon);
+    d->colorToolBar->setVisible(!showRibbon);
+    // d->toolToolBar->setVisible(!on);
+
+    // KToolBars
+    if (showRibbon)
+    {
+        toolBar(QLatin1String("textToolBar"))->hide();
+        toolBar(QLatin1String("mainToolBar"))->hide();
+    }
+    else
+    {
+        toolBar(QLatin1String("mainToolBar"))->show();
+    }
+
+    // Move the color palette widget to wherever it needs to be
+    if (showRibbon)
+        d->colorPaletteContainer->addWidget(d->colorPalette);
+    else
+        d->colorToolBar->m_boxLayout->insertWidget(1, d->colorPalette);
 }
 
 //---------------------------------------------------------------------

--- a/mainWindow/kpMainWindow_Text.cpp
+++ b/mainWindow/kpMainWindow_Text.cpp
@@ -28,6 +28,8 @@
 #include "mainWindow/kpMainWindow.h"
 #include "kpMainWindowPrivate.h"
 
+#include <SARibbonBar/SARibbonContextCategory.h>
+
 #include <KActionCollection>
 #include <KSharedConfig>
 #include <KConfigGroup>
@@ -140,6 +142,17 @@ void kpMainWindow::enableTextToolBarActions (bool enable)
         //         the Main Tool Bar, if there isn't enough room.  This makes
         //         accessing the Text Tool Bar's buttons difficult.
         textToolBar ()->setVisible (enable);
+    }
+
+    if (d->ribbon)
+    {
+        if (enable)
+        {
+            d->ribbon->showContextCategory(d->ribTextTools);
+            d->ribbon->raiseCategory(d->ribTextTools->categoryPage(0));
+        }
+        else
+            d->ribbon->hideContextCategory(d->ribTextTools);
     }
 }
 

--- a/mainWindow/kpMainWindow_Text.cpp
+++ b/mainWindow/kpMainWindow_Text.cpp
@@ -141,7 +141,9 @@ void kpMainWindow::enableTextToolBarActions (bool enable)
         // COMPAT: KDE4 does not place the Text Tool Bar in a new row, underneath
         //         the Main Tool Bar, if there isn't enough room.  This makes
         //         accessing the Text Tool Bar's buttons difficult.
-        textToolBar ()->setVisible (enable);
+
+        if (!d->configShowRibbon)
+            textToolBar ()->setVisible (enable);
     }
 
     if (d->ribbon)

--- a/mainWindow/kpMainWindow_Tools.cpp
+++ b/mainWindow/kpMainWindow_Tools.cpp
@@ -128,6 +128,11 @@ void kpMainWindow::setupToolActions ()
     d->tools.append (d->toolZoom = new kpToolZoom (toolEnv, this));
 
 
+    d->toolsExclude.append (d->toolFreeFormSelection);
+    d->toolsExclude.append (d->toolRectSelection);
+    d->toolsExclude.append (d->toolEllipticalSelection);
+
+
     KActionCollection *ac = actionCollection ();
 
     d->actionPrevToolOptionGroup1 = ac->addAction (QStringLiteral("prev_tool_option_group_1"));
@@ -176,8 +181,7 @@ void kpMainWindow::setupToolActions ()
 // private
 void kpMainWindow::createToolBox ()
 {
-    d->toolToolBar = new kpToolToolBar(QStringLiteral("Tool Box"), 2/*columns/rows*/, this);
-    d->toolToolBar->setWindowTitle(i18n("Tool Box"));
+    d->toolToolBar = new kpToolToolBar(this, d->ribbonPgHome);
 
     connect (d->toolToolBar, &kpToolToolBar::sigToolSelected,
              this, &kpMainWindow::slotToolSelected);
@@ -192,7 +196,8 @@ void kpMainWindow::createToolBox ()
     updateActionDrawOpaqueChecked ();
 
     for (auto *tool : d->tools) {
-      d->toolToolBar->registerTool(tool);
+        if (!d->toolsExclude.contains(tool))
+                d->toolToolBar->registerTool(tool);
     }
 
     // (from config file)
@@ -291,7 +296,6 @@ void kpMainWindow::updateActionDrawOpaqueChecked ()
 #if DEBUG_KP_MAIN_WINDOW
     qCDebug(kpLogMainWindow) << "\tdrawOpaque=" << drawOpaque;
 #endif
-    fprintf(stderr, "\tswitched: %b\n", drawOpaque);
     d->actionDrawOpaque->setChecked (drawOpaque);
 }
 

--- a/mainWindow/kpMainWindow_Tools.cpp
+++ b/mainWindow/kpMainWindow_Tools.cpp
@@ -196,8 +196,7 @@ void kpMainWindow::createToolBox ()
     updateActionDrawOpaqueChecked ();
 
     for (auto *tool : d->tools) {
-        if (!d->toolsExclude.contains(tool))
-                d->toolToolBar->registerTool(tool);
+        d->toolToolBar->registerTool(tool, d->toolsExclude.contains(tool));
     }
 
     // (from config file)
@@ -292,7 +291,7 @@ void kpMainWindow::updateActionDrawOpaqueChecked ()
 #endif
 
     const bool drawOpaque =
-        (d->bgroupOpaqueOrTransparent->checkedId() == 0);
+        (d->toolToolBar->toolWidgetOpaqueOrTransparent ()->selectedRow () == 0);
 #if DEBUG_KP_MAIN_WINDOW
     qCDebug(kpLogMainWindow) << "\tdrawOpaque=" << drawOpaque;
 #endif

--- a/mainWindow/kpMainWindow_Tools.cpp
+++ b/mainWindow/kpMainWindow_Tools.cpp
@@ -30,6 +30,7 @@
 #include "kpMainWindowPrivate.h"
 
 #include <QActionGroup>
+#include <QButtonGroup>
 
 #include <KActionCollection>
 #include <KSharedConfig>
@@ -286,11 +287,11 @@ void kpMainWindow::updateActionDrawOpaqueChecked ()
 #endif
 
     const bool drawOpaque =
-        (d->toolToolBar->toolWidgetOpaqueOrTransparent ()->selectedRow () == 0);
+        (d->bgroupOpaqueOrTransparent->checkedId() == 0);
 #if DEBUG_KP_MAIN_WINDOW
     qCDebug(kpLogMainWindow) << "\tdrawOpaque=" << drawOpaque;
 #endif
-
+    fprintf(stderr, "\tswitched: %b\n", drawOpaque);
     d->actionDrawOpaque->setChecked (drawOpaque);
 }
 

--- a/mainWindow/kpMainWindow_View.cpp
+++ b/mainWindow/kpMainWindow_View.cpp
@@ -48,6 +48,47 @@
 #include "views/kpZoomedView.h"
 #include "views/kpZoomedThumbnailView.h"
 
+#include <SARibbonBar/SARibbonCategory.h>
+#include <SARibbonBar/SARibbonPannel.h>
+
+static QAction* createAction(QMainWindow *win, const char *text, const char *iconurl)
+{
+    QAction* act = new QAction(win);
+    act->setText(QLatin1String(text));
+    act->setIcon(QIcon(QLatin1String(iconurl)));
+    act->setObjectName(QLatin1String(text));
+    win->connect(act, &QAction::triggered, win, [ win, act ]() {
+        // InnerWidget* w = qobject_cast< InnerWidget* >(widget());
+        // if (w) {
+        //     w->appendText(QString("action(%1) triggered").arg(act->text()));
+        // }
+    });
+    return act;
+}
+
+void kpMainWindow::setupRibbon()
+{
+    d->ribbon->setTitleVisible(false);
+    d->ribbon->setRibbonStyle(SARibbonBar::RibbonStyleCompactThreeRow);
+    d->ribbon->setApplicationButton(nullptr);
+
+
+    SARibbonCategory* page1 = new SARibbonCategory();
+    page1->setCategoryName(QLatin1String("page1"));
+    SARibbonPannel* pannel1 = new SARibbonPannel(QLatin1String("pannel1"), page1);
+    page1->addPannel(pannel1);
+    QAction* act = createAction(this, "  save  ", ":/icon/icon/save.svg");
+    act->setIconText(QLatin1String("  save  "));
+    pannel1->addLargeAction(act);
+    pannel1->addLargeAction(createAction(this, "open", ":/icon/icon/folder-star.svg"));
+    pannel1->addSmallAction(createAction(this, "action1", ":/icon/icon/action.svg"));
+    pannel1->addSmallAction(createAction(this, "action2", ":/icon/icon/action2.svg"));
+    SARibbonPannel* pannel2 = new SARibbonPannel(QLatin1String("pannel2"), page1);
+    page1->addPannel(pannel2);
+    pannel2->addLargeAction(createAction(this, "setting", ":/icon/icon/customize0.svg"));
+    pannel2->addLargeAction(createAction(this, "windowsflag", ":/icon/icon/windowsflag-normal.svg"));
+    d->ribbon->addCategoryPage(page1);
+}
 
 // private
 void kpMainWindow::setupViewMenuActions ()

--- a/mainWindow/kpMainWindow_View.cpp
+++ b/mainWindow/kpMainWindow_View.cpp
@@ -48,47 +48,6 @@
 #include "views/kpZoomedView.h"
 #include "views/kpZoomedThumbnailView.h"
 
-#include <SARibbonBar/SARibbonCategory.h>
-#include <SARibbonBar/SARibbonPannel.h>
-
-static QAction* createAction(QMainWindow *win, const char *text, const char *iconurl)
-{
-    QAction* act = new QAction(win);
-    act->setText(QLatin1String(text));
-    act->setIcon(QIcon(QLatin1String(iconurl)));
-    act->setObjectName(QLatin1String(text));
-    win->connect(act, &QAction::triggered, win, [ win, act ]() {
-        // InnerWidget* w = qobject_cast< InnerWidget* >(widget());
-        // if (w) {
-        //     w->appendText(QString("action(%1) triggered").arg(act->text()));
-        // }
-    });
-    return act;
-}
-
-void kpMainWindow::setupRibbon()
-{
-    d->ribbon->setTitleVisible(false);
-    d->ribbon->setRibbonStyle(SARibbonBar::RibbonStyleCompactThreeRow);
-    d->ribbon->setApplicationButton(nullptr);
-
-
-    SARibbonCategory* page1 = new SARibbonCategory();
-    page1->setCategoryName(QLatin1String("page1"));
-    SARibbonPannel* pannel1 = new SARibbonPannel(QLatin1String("pannel1"), page1);
-    page1->addPannel(pannel1);
-    QAction* act = createAction(this, "  save  ", ":/icon/icon/save.svg");
-    act->setIconText(QLatin1String("  save  "));
-    pannel1->addLargeAction(act);
-    pannel1->addLargeAction(createAction(this, "open", ":/icon/icon/folder-star.svg"));
-    pannel1->addSmallAction(createAction(this, "action1", ":/icon/icon/action.svg"));
-    pannel1->addSmallAction(createAction(this, "action2", ":/icon/icon/action2.svg"));
-    SARibbonPannel* pannel2 = new SARibbonPannel(QLatin1String("pannel2"), page1);
-    page1->addPannel(pannel2);
-    pannel2->addLargeAction(createAction(this, "setting", ":/icon/icon/customize0.svg"));
-    pannel2->addLargeAction(createAction(this, "windowsflag", ":/icon/icon/windowsflag-normal.svg"));
-    d->ribbon->addCategoryPage(page1);
-}
 
 // private
 void kpMainWindow::setupViewMenuActions ()

--- a/mainWindow/kpMainWindow_View_Zoom.cpp
+++ b/mainWindow/kpMainWindow_View_Zoom.cpp
@@ -97,6 +97,7 @@ void kpMainWindow::setupViewMenuZoomActions ()
 
 
     d->actionActualSize = KStandardAction::actualSize (this, SLOT (slotActualSize()), ac);
+    d->actionActualSize->setText(QLatin1String("1:1"));
     d->actionFitToPage = KStandardAction::fitToPage (this, SLOT (slotFitToPage()), ac);
     d->actionFitToWidth = KStandardAction::fitToWidth (this, SLOT (slotFitToWidth()), ac);
     d->actionFitToHeight = KStandardAction::fitToHeight (this, SLOT (slotFitToHeight()), ac);

--- a/widgets/toolbars/kpColorToolBar.cpp
+++ b/widgets/toolbars/kpColorToolBar.cpp
@@ -79,26 +79,6 @@ kpColorToolBar::kpColorToolBar (const QString &label, QWidget *parent)
 
     m_boxLayout->addWidget (m_dualColorButton, 0/*stretch*/, Qt::AlignVCenter);
 
-    m_colorPalette = new kpColorPalette (base);
-    connect (m_colorPalette, &kpColorPalette::foregroundColorChanged,
-             m_dualColorButton, &kpDualColorButton::setForegroundColor);
-
-    connect (m_colorPalette, &kpColorPalette::backgroundColorChanged,
-             m_dualColorButton, &kpDualColorButton::setBackgroundColor);
-
-    connect (m_colorPalette->colorCells (), &kpColorCells::isModifiedChanged,
-             this, &kpColorToolBar::updateNameOrUrlLabel);
-
-    connect (m_colorPalette->colorCells (), &kpColorCells::urlChanged,
-             this, &kpColorToolBar::updateNameOrUrlLabel);
-
-    connect (m_colorPalette->colorCells (), &kpColorCells::nameChanged,
-             this, &kpColorToolBar::updateNameOrUrlLabel);
-
-    updateNameOrUrlLabel ();
-
-    m_boxLayout->addWidget (m_colorPalette, 0/*stretch*/);
-
     m_colorSimilarityToolBarItem = new kpColorSimilarityToolBarItem (base);
     connect (m_colorSimilarityToolBarItem,
              &kpColorSimilarityToolBarItem::colorSimilarityChanged,
@@ -164,16 +144,6 @@ void kpColorToolBar::adjustToOrientation (Qt::Orientation o)
     {
         m_boxLayout->setDirection (QBoxLayout::TopToBottom);
     }
-
-    m_colorPalette->setOrientation (o);
-}
-
-//---------------------------------------------------------------------
-
-// public
-kpColorCells *kpColorToolBar::colorCells () const
-{
-    return m_colorPalette->colorCells ();
 }
 
 //---------------------------------------------------------------------
@@ -285,60 +255,6 @@ void kpColorToolBar::openColorSimilarityDialog ()
 void kpColorToolBar::flashColorSimilarityToolBarItem ()
 {
     m_colorSimilarityToolBarItem->flash ();
-}
-
-//---------------------------------------------------------------------
-
-// private slot
-void kpColorToolBar::updateNameOrUrlLabel ()
-{
-    QString name;
-
-    kpColorCells *colorCells = m_colorPalette->colorCells ();
-    if (!colorCells->url ().isEmpty ()) {
-        name = kpUrlFormatter::PrettyFilename (colorCells->url ());
-    }
-    else
-    {
-        if (!colorCells->name ().isEmpty ()) {
-            name = colorCells->name ();
-        }
-        else {
-            name = i18n ("KolourPaint Defaults");
-        }
-    }
-
-    if (name.isEmpty ()) {
-        name = i18n ("Untitled");
-    }
-
-
-    KLocalizedString labelStr;
-
-    if (!m_colorPalette->colorCells ()->isModified ())
-    {
-        labelStr =
-            ki18nc ("Colors: name_or_url_of_color_palette",
-                    "Colors: %1")
-                .subs (name);
-    }
-    else
-    {
-        labelStr =
-            ki18nc ("Colors: name_or_url_of_color_palette [modified]",
-                    "Colors: %1 [modified]")
-                .subs (name);
-    }
-
-    // Kill 2 birds with 1 stone:
-    //
-    // 1. Hide the windowTitle() when it's docked.
-    // 2. Add a label containing the name of the open color palette.
-    //
-    // TODO: This currently hides the windowTitle() even when it's not docked,
-    //       because we've abused it to show the name of open color palette
-    //       instead.
-    setWindowTitle (labelStr.toString ());
 }
 
 //---------------------------------------------------------------------

--- a/widgets/toolbars/kpColorToolBar.h
+++ b/widgets/toolbars/kpColorToolBar.h
@@ -58,6 +58,7 @@ class kpDualColorButton;
 class kpColorToolBar : public QDockWidget
 {
 Q_OBJECT
+    friend class kpMainWindow;
 
 public:
     kpColorToolBar (const QString &label, QWidget *parent);

--- a/widgets/toolbars/kpColorToolBar.h
+++ b/widgets/toolbars/kpColorToolBar.h
@@ -103,9 +103,6 @@ public Q_SLOTS:
     void setForegroundColor (const kpColor &color);
     void setBackgroundColor (const kpColor &color);
 
-private Q_SLOTS:
-    void updateNameOrUrlLabel ();
-
 protected:
     // Eat color drops (which are usually accidental drags from one of our
     // child widgets) to prevent them from being pasted as text in the
@@ -124,7 +121,6 @@ private:
     QBoxLayout *m_boxLayout;
     QList<QAction *> m_customContextMenuActions;
     kpDualColorButton *m_dualColorButton;
-    kpColorPalette *m_colorPalette;
     kpColorSimilarityToolBarItem *m_colorSimilarityToolBarItem;
     bool m_locked = true;
 };

--- a/widgets/toolbars/kpToolToolBar.cpp
+++ b/widgets/toolbars/kpToolToolBar.cpp
@@ -117,7 +117,7 @@ kpToolToolBar::~kpToolToolBar()
 //---------------------------------------------------------------------
 
 // public
-void kpToolToolBar::registerTool (kpTool *tool)
+void kpToolToolBar::registerTool (kpTool *tool, bool dontMakeButton)
 {
     int numTools = 0;
     for (auto *row : m_toolsRows)
@@ -127,20 +127,13 @@ void kpToolToolBar::registerTool (kpTool *tool)
 
         numTools += row->actions().count();
     }
-
-    m_toolsRows[numTools % m_toolsRows.count()]->addAction(tool->action());
+        
+    if (!dontMakeButton)
+        m_toolsRows[numTools % m_toolsRows.count()]->addAction(tool->action());
 
     connect (tool, &kpTool::actionActivated, [&, tool]() {
         selectTool (tool, true/*reselect if same tool*/);
     });
-}
-
-//---------------------------------------------------------------------
-// public
-
-void kpToolToolBar::unregisterTool(kpTool *tool)
-{
-    qDebug() << "kpToolToolBar::unregisterTool() not implemented. Code shouldn't be calling this.";
 }
 
 //---------------------------------------------------------------------

--- a/widgets/toolbars/kpToolToolBar.h
+++ b/widgets/toolbars/kpToolToolBar.h
@@ -41,6 +41,10 @@ class QBoxLayout;
 class QButtonGroup;
 class QGridLayout;
 class QWidget;
+class QWidgetAction;
+
+class SARibbonPannel;
+class SARibbonButtonGroupWidget;
 
 class kpTool;
 class kpToolButton;
@@ -65,7 +69,7 @@ public:
     void unregisterTool(kpTool *tool);
 
     kpTool *tool () const;
-    void selectTool (const kpTool *tool, bool reselectIfSameTool = false);
+    void selectTool (kpTool *tool, bool reselectIfSameTool = false);
 
     kpTool *previousTool () const;
     void selectPreviousTool ();
@@ -90,9 +94,7 @@ Q_SIGNALS:
     void toolWidgetOptionSelected ();
 
 private Q_SLOTS:
-    void slotToolButtonClicked ();
-
-    void slotToolActionActivated ();
+    void slotToolButtonClicked (kpTool *tool);
 
     void adjustToOrientation(Qt::Orientation o);
     void slotIconSizeChanged(const QSize &);
@@ -104,8 +106,7 @@ private:
 
     int m_vertCols;
 
-    QButtonGroup *m_buttonGroup;
-    QWidget *m_baseWidget;
+    SARibbonPannel *m_baseWidget;
     QBoxLayout *m_baseLayout;
     QGridLayout *m_toolLayout;
 
@@ -119,6 +120,8 @@ private:
     QList<kpToolWidgetBase *> m_toolWidgets;
 
     QList<kpToolButton *> m_toolButtons;
+
+    QList<SARibbonButtonGroupWidget *> m_toolsRows;
 
     kpTool *m_previousTool, *m_currentTool;
 };

--- a/widgets/toolbars/kpToolToolBar.h
+++ b/widgets/toolbars/kpToolToolBar.h
@@ -44,6 +44,7 @@ class QWidget;
 class QWidgetAction;
 
 class SARibbonPannel;
+class SARibbonCategory;
 class SARibbonButtonGroupWidget;
 
 class kpTool;
@@ -57,12 +58,12 @@ class kpToolWidgetLineWidth;
 class kpToolWidgetOpaqueOrTransparent;
 class kpToolWidgetSpraycanSize;
 
-class kpToolToolBar : public KToolBar
+class kpToolToolBar : public QObject
 {
 Q_OBJECT
 
 public:
-    kpToolToolBar (const QString &name, int colsOrRows, QMainWindow *parent);
+    kpToolToolBar (QMainWindow *parent, SARibbonCategory *ribbonPageForPannels);
     ~kpToolToolBar () override;
 
     void registerTool(kpTool *tool);
@@ -85,9 +86,8 @@ public:
 
     kpToolWidgetBase *shownToolWidget (int which) const;
 
-protected:
-    bool event(QEvent *ev) override;
-    void paintEvent(QPaintEvent *) override;
+    void setEnabled(bool enabled);
+    bool isEnabled();
 
 Q_SIGNALS:
     void sigToolSelected (kpTool *tool);  // tool may be 0
@@ -96,19 +96,10 @@ Q_SIGNALS:
 private Q_SLOTS:
     void slotToolButtonClicked (kpTool *tool);
 
-    void adjustToOrientation(Qt::Orientation o);
-    void slotIconSizeChanged(const QSize &);
-    void slotToolButtonStyleChanged(Qt::ToolButtonStyle style);
-
 private:
-    void addButton (QAbstractButton *button, Qt::Orientation o, int num);
     void adjustSizeConstraint();
 
-    int m_vertCols;
-
-    SARibbonPannel *m_baseWidget;
-    QBoxLayout *m_baseLayout;
-    QGridLayout *m_toolLayout;
+    SARibbonPannel *m_pnTools, *m_pnParams;
 
     kpToolWidgetBrush *m_toolWidgetBrush;
     kpToolWidgetEraserSize *m_toolWidgetEraserSize;
@@ -118,8 +109,6 @@ private:
     kpToolWidgetSpraycanSize *m_toolWidgetSpraycanSize;
 
     QList<kpToolWidgetBase *> m_toolWidgets;
-
-    QList<kpToolButton *> m_toolButtons;
 
     QList<SARibbonButtonGroupWidget *> m_toolsRows;
 

--- a/widgets/toolbars/kpToolToolBar.h
+++ b/widgets/toolbars/kpToolToolBar.h
@@ -66,8 +66,7 @@ public:
     kpToolToolBar (QMainWindow *parent, SARibbonCategory *ribbonPageForPannels);
     ~kpToolToolBar () override;
 
-    void registerTool(kpTool *tool);
-    void unregisterTool(kpTool *tool);
+    void registerTool(kpTool *tool, bool dontMakeButton);
 
     kpTool *tool () const;
     void selectTool (kpTool *tool, bool reselectIfSameTool = false);

--- a/widgets/toolbars/kpToolToolBar_original.cpp
+++ b/widgets/toolbars/kpToolToolBar_original.cpp
@@ -1,0 +1,500 @@
+/*
+   Copyright (c) 2003-2007 Clarence Dang <dang@kde.org>
+   Copyright (c) 2011      Martin Koller <kollix@aon.at>
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+   IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+   OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+   IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+   INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+   NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+   THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+
+#define DEBUG_KP_TOOL_TOOL_BAR 0
+
+
+#include "widgets/toolbars/kpToolToolBar.h"
+
+#include <QBoxLayout>
+#include <QGridLayout>
+#include <QButtonGroup>
+#include <QKeyEvent>
+#include <QToolButton>
+#include <QStyleOption>
+#include <QStylePainter>
+
+#include <KToggleAction>
+
+#include "kpLogCategories.h"
+
+#include "kpDefs.h"
+#include "tools/kpTool.h"
+#include "widgets/toolbars/options/kpToolWidgetBrush.h"
+#include "widgets/toolbars/options/kpToolWidgetEraserSize.h"
+#include "widgets/toolbars/options/kpToolWidgetFillStyle.h"
+#include "widgets/toolbars/options/kpToolWidgetLineWidth.h"
+#include "widgets/toolbars/options/kpToolWidgetOpaqueOrTransparent.h"
+#include "widgets/toolbars/options/kpToolWidgetSpraycanSize.h"
+
+//---------------------------------------------------------------------
+
+class kpToolButton : public QToolButton
+{
+public:
+    kpToolButton (kpTool *tool, QWidget *parent)
+        : QToolButton (parent),
+          m_tool (tool)
+    {
+    }
+
+    kpTool *tool() const { return m_tool; }
+
+protected:
+    void mouseDoubleClickEvent(QMouseEvent *e) override
+    {
+        if (e->button () == Qt::LeftButton && m_tool) {
+            m_tool->globalDraw ();
+        }
+    }
+
+    kpTool *m_tool;
+};
+
+//---------------------------------------------------------------------
+
+kpToolToolBar::kpToolToolBar(const QString &name, int colsOrRows, QMainWindow *parent)
+    : KToolBar(name, parent, Qt::LeftToolBarArea),
+      m_vertCols (colsOrRows),
+      m_buttonGroup (nullptr),
+      m_baseWidget (nullptr),
+      m_baseLayout (nullptr),
+      m_toolLayout (nullptr),
+      m_previousTool (nullptr), m_currentTool (nullptr)
+{
+    m_baseWidget = new QWidget(this);
+
+    m_toolWidgets.append (m_toolWidgetBrush =
+        new kpToolWidgetBrush (m_baseWidget, QStringLiteral("Tool Widget Brush")));
+    m_toolWidgets.append (m_toolWidgetEraserSize =
+        new kpToolWidgetEraserSize (m_baseWidget, QStringLiteral("Tool Widget Eraser Size")));
+    m_toolWidgets.append (m_toolWidgetFillStyle =
+        new kpToolWidgetFillStyle (m_baseWidget, QStringLiteral("Tool Widget Fill Style")));
+    m_toolWidgets.append (m_toolWidgetLineWidth =
+        new kpToolWidgetLineWidth (m_baseWidget, QStringLiteral("Tool Widget Line Width")));
+    m_toolWidgets.append (m_toolWidgetOpaqueOrTransparent =
+        new kpToolWidgetOpaqueOrTransparent (m_baseWidget, QStringLiteral("Tool Widget Opaque/Transparent")));
+    m_toolWidgets.append (m_toolWidgetSpraycanSize =
+        new kpToolWidgetSpraycanSize (m_baseWidget, QStringLiteral("Tool Widget Spraycan Size")));
+
+    for (auto *w : m_toolWidgets)
+    {
+      connect (w, &kpToolWidgetBase::optionSelected,
+               this, &kpToolToolBar::toolWidgetOptionSelected);
+    }
+
+    adjustToOrientation(orientation());
+    connect (this, &kpToolToolBar::orientationChanged,
+             this, &kpToolToolBar::adjustToOrientation);
+
+    m_buttonGroup = new QButtonGroup (this);
+    connect (m_buttonGroup, &QButtonGroup::idClicked,
+             this, &kpToolToolBar::slotToolButtonClicked);
+
+    hideAllToolWidgets ();
+
+    addWidget(m_baseWidget);
+
+    connect (this, &kpToolToolBar::iconSizeChanged,
+             this, &kpToolToolBar::slotIconSizeChanged);
+
+    connect (this, &kpToolToolBar::toolButtonStyleChanged,
+             this, &kpToolToolBar::slotToolButtonStyleChanged);
+}
+
+//---------------------------------------------------------------------
+
+kpToolToolBar::~kpToolToolBar()
+{
+    while ( !m_toolButtons.isEmpty() ) {
+        delete m_toolButtons.takeFirst();
+    }
+}
+
+//---------------------------------------------------------------------
+
+// public
+void kpToolToolBar::registerTool (kpTool *tool)
+{
+    for (const auto *b : m_toolButtons)
+    {
+        if ( b->tool() == tool ) {  // already given
+            return;
+        }
+    }
+
+    auto *b = new kpToolButton(tool, m_baseWidget);
+
+    b->setToolButtonStyle(toolButtonStyle());
+    b->setIconSize(iconSize());
+    b->setAutoRaise(true);
+
+    // tell layout to make all with equal width (much better when text-below-icon)
+    b->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+
+    b->setDefaultAction(tool->action());
+
+    m_buttonGroup->addButton(b);
+    addButton(b, orientation(), m_toolButtons.count());
+
+    m_toolButtons.append(b);
+
+    connect (tool, &kpTool::actionActivated,
+             this, &kpToolToolBar::slotToolActionActivated);
+
+    adjustSizeConstraint();
+}
+
+//---------------------------------------------------------------------
+// public
+
+void kpToolToolBar::unregisterTool(kpTool *tool)
+{
+    for (int i = 0; i < m_toolButtons.count(); i++)
+    {
+      if ( m_toolButtons[i]->tool() == tool )
+      {
+        delete m_toolButtons.takeAt(i);
+        disconnect (tool, &kpTool::actionActivated,
+                 this, &kpToolToolBar::slotToolActionActivated);
+        return;
+      }
+    }
+}
+
+//---------------------------------------------------------------------
+// public
+
+kpTool *kpToolToolBar::tool () const
+{
+    return m_currentTool;
+}
+
+//---------------------------------------------------------------------
+
+// public
+void kpToolToolBar::selectTool (const kpTool *tool, bool reselectIfSameTool)
+{
+#if DEBUG_KP_TOOL_TOOL_BAR
+    qCDebug(kpLogWidgets) << "kpToolToolBar::selectTool (tool=" << tool
+               << ") currentTool=" << m_currentTool
+               << endl;
+#endif
+
+    if (!reselectIfSameTool && tool == m_currentTool) {
+        return;
+    }
+
+    if (tool)
+    {
+      tool->action()->setChecked(true);
+      slotToolButtonClicked();
+    }
+    else
+    {
+        QAbstractButton *b = m_buttonGroup->checkedButton();
+        if (b)
+        {
+            // HACK: qbuttongroup.html says the following about exclusive
+            //       button groups:
+            //
+            //           "to untoggle a button you must click on another button
+            //            in the group"
+            //
+            //       But we don't want any button to be selected.
+            //       So don't be an exclusive button group temporarily.
+            m_buttonGroup->setExclusive (false);
+            b->setChecked (false);
+            m_buttonGroup->setExclusive (true);
+
+            slotToolButtonClicked ();
+        }
+    }
+}
+
+//---------------------------------------------------------------------
+
+// public
+kpTool *kpToolToolBar::previousTool () const
+{
+    return m_previousTool;
+}
+
+//---------------------------------------------------------------------
+
+// public
+void kpToolToolBar::selectPreviousTool ()
+{
+    selectTool (m_previousTool);
+}
+
+//---------------------------------------------------------------------
+
+// public
+void kpToolToolBar::hideAllToolWidgets ()
+{
+    for (auto *w : m_toolWidgets) {
+      w->hide ();
+    }
+}
+
+//---------------------------------------------------------------------
+
+// public
+kpToolWidgetBase *kpToolToolBar::shownToolWidget (int which) const
+{
+    int uptoVisibleWidget = 0;
+
+    for(auto *w : m_toolWidgets)
+    {
+        if ( !w->isHidden() )
+        {
+            if (which == uptoVisibleWidget) {
+                return w;
+            }
+
+            uptoVisibleWidget++;
+        }
+    }
+
+    return nullptr;
+}
+
+//---------------------------------------------------------------------
+
+// private slot
+void kpToolToolBar::slotToolButtonClicked ()
+{
+    QAbstractButton *b = m_buttonGroup->checkedButton();
+
+#if DEBUG_KP_TOOL_TOOL_BAR
+    qCDebug(kpLogWidgets) << "kpToolToolBar::slotToolButtonClicked() button=" << b;
+#endif
+
+    kpTool *tool = nullptr;
+    for (const auto *button : m_toolButtons)
+    {
+      if ( button == b )
+      {
+        tool = button->tool();
+        break;
+      }
+    }
+
+#if DEBUG_KP_TOOL_TOOL_BAR
+    qCDebug(kpLogWidgets) << "\ttool=" << tool
+               << " currentTool=" << m_currentTool
+               << endl;
+#endif
+
+    if (tool == m_currentTool)
+    {
+        if (m_currentTool) {
+            m_currentTool->reselect ();
+        }
+
+        return;
+    }
+
+    if (m_currentTool) {
+        m_currentTool->endInternal ();
+    }
+
+    m_previousTool = m_currentTool;
+    m_currentTool = tool;
+
+    if (m_currentTool)
+    {
+        KToggleAction *action = m_currentTool->action ();
+        if (action)
+        {
+            action->setChecked (true);
+        }
+
+        m_currentTool->beginInternal ();
+    }
+
+    Q_EMIT sigToolSelected (m_currentTool);
+    m_baseLayout->activate();
+    adjustSizeConstraint();
+}
+
+//---------------------------------------------------------------------
+
+// private slot
+void kpToolToolBar::slotToolActionActivated ()
+{
+    const auto *tool = dynamic_cast<const kpTool *>(sender());
+
+#if DEBUG_KP_TOOL_TOOL_BAR
+    qCDebug(kpLogWidgets) << "kpToolToolBar::slotToolActionActivated() tool="
+               << (tool ? tool->objectName () : "null")
+               << endl;
+#endif
+
+    selectTool (tool, true/*reselect if same tool*/);
+}
+
+//---------------------------------------------------------------------
+
+// public
+void kpToolToolBar::adjustToOrientation(Qt::Orientation o)
+{
+#if DEBUG_KP_TOOL_TOOL_BAR
+    qCDebug(kpLogWidgets) << "kpToolToolBar::adjustToOrientation("
+               << (o == Qt::Vertical ? "vertical" : "horizontal")
+               << ") called!" << endl;
+#endif
+
+    delete m_baseLayout;
+    if (o == Qt::Vertical)
+    {
+        m_baseLayout = new QBoxLayout (QBoxLayout::TopToBottom, m_baseWidget);
+    }
+    else // if (o == Qt::Horizontal)
+    {
+        m_baseLayout = new QBoxLayout (QBoxLayout::LeftToRight, m_baseWidget);
+    }
+    m_baseLayout->setSizeConstraint(QLayout::SetFixedSize);
+    m_baseLayout->setContentsMargins(0, 0, 0, 0);
+
+    m_toolLayout = new QGridLayout();
+    m_toolLayout->setContentsMargins(0, 0, 0, 0);
+
+    // (ownership is transferred to m_baseLayout)
+    m_baseLayout->addItem (m_toolLayout);
+
+    auto num = 0;
+
+    for (auto *b : m_toolButtons)
+    {
+      addButton(b, o, num);
+      num++;
+    }
+
+    for (auto *w : m_toolWidgets)
+    {
+      m_baseLayout->addWidget(w,
+          0/*stretch*/,
+          o == Qt::Vertical ? Qt::AlignHCenter : Qt::AlignVCenter);
+    }
+
+    adjustSizeConstraint();
+}
+
+
+bool kpToolToolBar::event(QEvent *ev)
+{
+    if (ev->type() == QEvent::LayoutRequest) {
+        adjustSizeConstraint();
+    }
+    return KToolBar::event(ev);
+}
+
+void kpToolToolBar::paintEvent(class QPaintEvent *)
+{
+    QStyleOption opt;
+    opt.initFrom(this);
+    if (opt.rect.height() <= contentsMargins().top() + contentsMargins().bottom() || opt.rect.width() <= contentsMargins().left() + contentsMargins().right()) {
+        return;
+    }
+
+    QStylePainter painter(this);
+
+    opt.rect.setX(opt.rect.width() - style()->pixelMetric(QStyle::PM_SplitterWidth));
+    opt.rect.setWidth(style()->pixelMetric(QStyle::PM_SplitterWidth));
+    opt.state = QStyle::State_Horizontal;
+
+    painter.drawPrimitive(QStyle::PE_IndicatorToolBarSeparator, opt);
+}
+
+//---------------------------------------------------------------------
+// this makes the size handled correctly during dragging/undocking the toolbar
+
+void kpToolToolBar::adjustSizeConstraint()
+{
+    // remove constraints
+    setFixedSize(QSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX));
+
+    if ( orientation() == Qt::Vertical )
+    {
+      setFixedWidth(m_baseLayout->sizeHint().width() +
+                    layout()->contentsMargins().left() +
+                    layout()->contentsMargins().right());
+    }
+    else
+    {
+      setFixedHeight(m_baseLayout->sizeHint().height() +
+                     layout()->contentsMargins().top() +
+                     layout()->contentsMargins().bottom());
+    }
+}
+
+//---------------------------------------------------------------------
+
+// private
+void kpToolToolBar::addButton(QAbstractButton *button, Qt::Orientation o, int num)
+{
+    if (o == Qt::Vertical) {
+        m_toolLayout->addWidget (button, num / m_vertCols, num % m_vertCols);
+    }
+    else
+    {
+        // maps Left (o = vertical) to Bottom (o = horizontal)
+        int row = (m_vertCols - 1) - (num % m_vertCols);
+        m_toolLayout->addWidget (button, row, num / m_vertCols);
+    }
+}
+
+//---------------------------------------------------------------------
+
+void kpToolToolBar::slotIconSizeChanged(const QSize &size)
+{
+    for (auto *b : m_toolButtons) {
+        b->setIconSize(size);
+    }
+
+    m_baseLayout->activate();
+    adjustSizeConstraint();
+}
+
+//---------------------------------------------------------------------
+
+void kpToolToolBar::slotToolButtonStyleChanged(Qt::ToolButtonStyle style)
+{
+    for (auto *b : m_toolButtons) {
+        b->setToolButtonStyle(style);
+    }
+
+    m_baseLayout->activate();
+    adjustSizeConstraint();
+}
+
+//---------------------------------------------------------------------
+
+#include "moc_kpToolToolBar.cpp"

--- a/widgets/toolbars/options/kpToolWidgetBase.cpp
+++ b/widgets/toolbars/options/kpToolWidgetBase.cpp
@@ -45,708 +45,708 @@
 #include <QToolTip>
 
 
-//---------------------------------------------------------------------
-
-kpToolWidgetBase::kpToolWidgetBase (QWidget *parent, const QString &name)
-    : QFrame(parent), m_baseWidget(nullptr),
-      m_selectedRow(-1), m_selectedCol(-1)
-{
-    setObjectName (name);
-
-    setFrameStyle (QFrame::Panel | QFrame::Sunken);
-
-    setFixedSize (44, 66);
-    setSizePolicy (QSizePolicy::Minimum, QSizePolicy::Minimum);
-}
-
-//---------------------------------------------------------------------
-
-kpToolWidgetBase::~kpToolWidgetBase () = default;
-
-//---------------------------------------------------------------------
-
-// public
-void kpToolWidgetBase::addOption (const QPixmap &pixmap, const QString &toolTip)
-{
-    if (m_pixmaps.isEmpty ()) {
-        startNewOptionRow ();
-    }
-
-    m_pixmaps.last ().append (pixmap);
-    m_pixmapRects.last ().append (QRect ());
-    m_toolTips.last ().append (toolTip);
-}
-
-//---------------------------------------------------------------------
-
-// public
-void kpToolWidgetBase::startNewOptionRow ()
-{
-    m_pixmaps.append (QList <QPixmap> ());
-    m_pixmapRects.append (QList <QRect> ());
-    m_toolTips.append (QList <QString> ());
-}
-
-//---------------------------------------------------------------------
-
-// public
-void kpToolWidgetBase::finishConstruction (int fallBackRow, int fallBackCol)
-{
-#if DEBUG_KP_TOOL_WIDGET_BASE
-    qCDebug(kpLogWidgets) << "kpToolWidgetBase(" << objectName ()
-               << ")::kpToolWidgetBase(fallBack:row=" << fallBackRow
-               << ",col=" << fallBackCol
-               << ")";
-#endif
-
-    relayoutOptions ();
-
-    // HACK: Undo the maximum half of setFixedSize() in the ctor to avoid
-    //       bizarre redraw errors when tool widgets are hidden and others
-    //       are shown.
-    //
-    //       The reason why we didn't just use setMinimumSize() in the ctor is
-    //       because all tool widgets construct pixmaps whose sizes are dependent
-    //       on the size() in the ctor, so we needed to get the correct size
-    //       in there.  This is bad design because it means that tool widgets
-    //       can't really be resized.
-    setMaximumSize (QWIDGETSIZE_MAX, QWIDGETSIZE_MAX);
-
-    const QPair <int, int> rowColPair = defaultSelectedRowAndCol ();
-    if (!setSelected (rowColPair.first, rowColPair.second, false/*don't save*/))
-    {
-        if (!setSelected (fallBackRow, fallBackCol))
-        {
-            if (!setSelected (0, 0))
-            {
-                qCCritical(kpLogWidgets) << "kpToolWidgetBase::finishConstruction() "
-                              "can't even fall back to setSelected(row=0,col=0)";
-            }
-        }
-    }
-}
-
-//---------------------------------------------------------------------
-
-// private
-QList <int> kpToolWidgetBase::spreadOutElements (const QList <int> &sizes, int max)
-{
-    if (sizes.count () == 0) {
-        return {};
-    }
-
-    if (sizes.count () == 1)
-    {
-        QList <int> ret;
-        ret.append (sizes.first () > max ? 0 : 1/*margin*/);
-        return ret;
-    }
-
-    QList <int> retOffsets;
-    for (int i = 0; i < sizes.count (); i++) {
-        retOffsets.append (0);
-    }
-
-    int totalSize = 0;
-    for (int i = 0; i <  sizes.count (); i++) {
-        totalSize += sizes [i];
-    }
-
-    int margin = 1;
-
-    // if don't fit with margin, then just return elements
-    // packed right next to each other
-    if (totalSize + margin * 2 > max)
-    {
-        retOffsets [0] = 0;
-        for (int i = 1; i < sizes.count (); i++) {
-            retOffsets [i] = retOffsets [i - 1] + sizes [i - 1];
-        }
-
-        return retOffsets;
-    }
-
-    int maxLeftOver = max - (totalSize + margin * 2 * sizes.count());
-
-    int startCompensating = -1;
-    int numCompensate = 0;
-
-    int spacing = 0;
-
-    spacing = maxLeftOver / (sizes.count () - 1);
-    if (spacing * int (sizes.count () - 1) < maxLeftOver)
-    {
-        numCompensate = maxLeftOver - spacing * (sizes.count () - 1);
-        startCompensating = ((sizes.count () - 1) - numCompensate) / 2;
-    }
-
-    retOffsets [0] = margin;
-    for (int i = 1; i < sizes.count (); i++)
-    {
-        retOffsets [i] += retOffsets [i - 1] +
-                          sizes [i - 1] +
-                          spacing +
-                          ((numCompensate &&
-                           i >= startCompensating &&
-                           i < startCompensating + numCompensate) ? 1 : 0);
-    }
-
-    return retOffsets;
-}
-
-//---------------------------------------------------------------------
-
-// public
-QPair <int, int> kpToolWidgetBase::defaultSelectedRowAndCol () const
-{
-    int row = -1, col = -1;
-
-    if (!objectName ().isEmpty ())
-    {
-        KConfigGroup cfg (KSharedConfig::openConfig (), QStringLiteral(kpSettingsGroupTools));
-
-        row = cfg.readEntry (objectName () + QLatin1String (" Row"), -1);
-        col = cfg.readEntry (objectName () + QLatin1String (" Col"), -1);
-    }
-
-#if DEBUG_KP_TOOL_WIDGET_BASE
-    qCDebug(kpLogWidgets) << "kpToolWidgetBase(" << objectName ()
-               << ")::defaultSelectedRowAndCol() returning row=" << row
-               << " col=" << col;
-#endif
-
-    return qMakePair (row, col);
-}
-
-//---------------------------------------------------------------------
-
-// public
-int kpToolWidgetBase::defaultSelectedRow () const
-{
-    return defaultSelectedRowAndCol ().first;
-}
-
-//---------------------------------------------------------------------
-
-// public
-int kpToolWidgetBase::defaultSelectedCol () const
-{
-    return defaultSelectedRowAndCol ().second;
-}
-
-//---------------------------------------------------------------------
-
-// public
-void kpToolWidgetBase::saveSelectedAsDefault () const
-{
-#if DEBUG_KP_TOOL_WIDGET_BASE
-    qCDebug(kpLogWidgets) << "kpToolWidgetBase(" << objectName ()
-               << ")::saveSelectedAsDefault() row=" << m_selectedRow
-               << " col=" << m_selectedCol;
-#endif
-
-    if (objectName ().isEmpty ()) {
-        return;
-    }
-
-    KConfigGroup cfg (KSharedConfig::openConfig (), QStringLiteral(kpSettingsGroupTools));
-
-    cfg.writeEntry (objectName () + QLatin1String (" Row"), m_selectedRow);
-    cfg.writeEntry (objectName () + QLatin1String (" Col"), m_selectedCol);
-    cfg.sync ();
-}
-
-//---------------------------------------------------------------------
-
-// public
-void kpToolWidgetBase::relayoutOptions ()
-{
-#if DEBUG_KP_TOOL_WIDGET_BASE
-    qCDebug(kpLogWidgets) << "kpToolWidgetBase::relayoutOptions() size=" << size ();
-#endif
-
-    while (!m_pixmaps.isEmpty () && m_pixmaps.last ().count () == 0)
-    {
-    #if DEBUG_KP_TOOL_WIDGET_BASE
-        qCDebug(kpLogWidgets) << "\tkilling #" << m_pixmaps.count () - 1;
-    #endif
-        m_pixmaps.removeLast ();
-        m_pixmapRects.removeLast ();
-        m_toolTips.removeLast ();
-    }
-
-    if (m_pixmaps.isEmpty ()) {
-        return;
-    }
-
-#if DEBUG_KP_TOOL_WIDGET_BASE
-    qCDebug(kpLogWidgets) << "\tsurvived killing of empty rows";
-    qCDebug(kpLogWidgets) << "\tfinding heights of rows:";
-#endif
-
-    QList <int> maxHeightOfRow;
-    for (int r = 0; r < m_pixmaps.count (); r++) {
-        maxHeightOfRow.append (0);
-    }
-
-    for (int r = 0; r <  m_pixmaps.count (); r++)
-    {
-        for (int c = 0; c <  m_pixmaps [r].count (); c++)
-        {
-            if (c == 0 || m_pixmaps [r][c].height () > maxHeightOfRow [r]) {
-                maxHeightOfRow [r] = m_pixmaps [r][c].height ();
-            }
-        }
-    #if DEBUG_KP_TOOL_WIDGET_BASE
-        qCDebug(kpLogWidgets) << "\t\t" << r << ": " << maxHeightOfRow [r];
-    #endif
-    }
-
-    QList <int> rowYOffset = spreadOutElements (maxHeightOfRow, height ());
-#if DEBUG_KP_TOOL_WIDGET_BASE
-    qCDebug(kpLogWidgets) << "\tspread out offsets of rows:";
-    for (int r = 0; r < (int) rowYOffset.count (); r++) {
-        qCDebug(kpLogWidgets) << "\t\t" << r << ": " << rowYOffset [r];
-    }
-#endif
-
-    for (int r = 0; r < m_pixmaps.count (); r++)
-    {
-    #if DEBUG_KP_TOOL_WIDGET_BASE
-        qCDebug(kpLogWidgets) << "\tlaying out row " << r << ":";
-    #endif
-
-        QList <int> widths;
-        for (int c = 0; c < m_pixmaps [r].count (); c++)
-            widths.append (m_pixmaps [r][c].width ());
-    #if DEBUG_KP_TOOL_WIDGET_BASE
-        qCDebug(kpLogWidgets) << "\t\twidths of cols:";
-        for (int c = 0; c <  m_pixmaps [r].count (); c++) {
-            qCDebug(kpLogWidgets) << "\t\t\t" << c << ": " << widths [c];
-        }
-    #endif
-
-        QList <int> colXOffset = spreadOutElements (widths, width ());
-    #if DEBUG_KP_TOOL_WIDGET_BASE
-        qCDebug(kpLogWidgets) << "\t\tspread out offsets of cols:";
-        for (int c = 0; c < colXOffset.count (); c++) {
-            qCDebug(kpLogWidgets) << "\t\t\t" << c << ": " << colXOffset [c];
-        }
-    #endif
-
-        for (int c = 0; c < colXOffset.count (); c++)
-        {
-            int x = colXOffset [c];
-            int y = rowYOffset [r];
-            int w, h;
-
-            if (c == colXOffset.count () - 1)
-            {
-                if (x + m_pixmaps [r][c].width () >= width ()) {
-                    w = m_pixmaps [r][c].width ();
-                }
-                else {
-                    w = width () - 1 - x;
-                }
-            }
-            else {
-                w = colXOffset [c + 1] - x;
-            }
-
-            if (r == m_pixmaps.count () - 1)
-            {
-                if (y + m_pixmaps [r][c].height () >= height ()) {
-                    h = m_pixmaps [r][c].height ();
-                }
-                else {
-                    h = height () - 1 - y;
-                }
-            }
-            else {
-                h = rowYOffset [r + 1] - y;
-            }
-
-            m_pixmapRects [r][c] = QRect (x, y, w, h);
-        }
-    }
-
-    update ();
-}
-
-//---------------------------------------------------------------------
-
-
-// public
-int kpToolWidgetBase::selectedRow () const
-{
-    return m_selectedRow;
-}
-
-//---------------------------------------------------------------------
-
-// public
-int kpToolWidgetBase::selectedCol () const
-{
-    return m_selectedCol;
-}
-
-//---------------------------------------------------------------------
-
-// public
-int kpToolWidgetBase::selected () const
-{
-    if (m_selectedRow < 0 ||
-        m_selectedRow >= m_pixmaps.count () ||
-        m_selectedCol < 0)
-    {
-        return -1;
-    }
-
-    int upto = 0;
-    for (int y = 0; y < m_selectedRow; y++) {
-        upto += m_pixmaps [y].count ();
-    }
-
-    if (m_selectedCol >= m_pixmaps [m_selectedRow].count ()) {
-        return -1;
-    }
-
-    upto += m_selectedCol;
-
-    return upto;
-}
-
-//---------------------------------------------------------------------
-
-
-// public
-bool kpToolWidgetBase::hasPreviousOption (int *row, int *col) const
-{
-#if DEBUG_KP_TOOL_WIDGET_BASE
-    qCDebug(kpLogWidgets) << "kpToolWidgetBase(" << objectName ()
-               << ")::hasPreviousOption() current row=" << m_selectedRow
-               << " col=" << m_selectedCol;
-#endif
-    if (row) {
-        *row = -1;
-    }
-    if (col) {
-        *col = -1;
-    }
-
-
-    if (m_selectedRow < 0 || m_selectedCol < 0) {
-        return false;
-    }
-
-    int newRow = m_selectedRow,
-        newCol = m_selectedCol;
-
-    newCol--;
-    if (newCol < 0)
-    {
-        newRow--;
-        if (newRow < 0) {
-            return false;
-        }
-
-        newCol = m_pixmaps [newRow].count () - 1;
-        if (newCol < 0) {
-            return false;
-        }
-    }
-
-
-    if (row) {
-        *row = newRow;
-    }
-    if (col) {
-        *col = newCol;
-    }
-
-    return true;
-}
-
-//---------------------------------------------------------------------
-
-// public
-bool kpToolWidgetBase::hasNextOption (int *row, int *col) const
-{
-#if DEBUG_KP_TOOL_WIDGET_BASE
-    qCDebug(kpLogWidgets) << "kpToolWidgetBase(" << objectName ()
-               << ")::hasNextOption() current row=" << m_selectedRow
-               << " col=" << m_selectedCol;
-#endif
-
-    if (row) {
-        *row = -1;
-    }
-    if (col) {
-        *col = -1;
-    }
-
-
-    if (m_selectedRow < 0 || m_selectedCol < 0) {
-        return false;
-    }
-
-    int newRow = m_selectedRow,
-        newCol = m_selectedCol;
-
-    newCol++;
-    if (newCol >= m_pixmaps [newRow].count ())
-    {
-        newRow++;
-        if (newRow >= m_pixmaps.count ()) {
-            return false;
-        }
-
-        newCol = 0;
-        if (newCol >= m_pixmaps [newRow].count ()) {
-            return false;
-        }
-    }
-
-
-    if (row) {
-        *row = newRow;
-    }
-    if (col) {
-        *col = newCol;
-    }
-
-    return true;
-}
-
-//---------------------------------------------------------------------
-
-
-// public slot virtual
-bool kpToolWidgetBase::setSelected (int row, int col, bool saveAsDefault)
-{
-#if DEBUG_KP_TOOL_WIDGET_BASE
-    qCDebug(kpLogWidgets) << "kpToolWidgetBase::setSelected(row=" << row
-               << ",col=" << col
-               << ",saveAsDefault=" << saveAsDefault
-               << ")";
-#endif
-
-    if (row < 0 || col < 0 ||
-        row >= m_pixmapRects.count () || col >= m_pixmapRects [row].count ())
-    {
-    #if DEBUG_KP_TOOL_WIDGET_BASE
-        qCDebug(kpLogWidgets) << "\tout of range";
-    #endif
-        return false;
-    }
-
-    if (row == m_selectedRow && col == m_selectedCol)
-    {
-    #if DEBUG_KP_TOOL_WIDGET_BASE
-        qCDebug(kpLogWidgets) << "\tNOP";
-    #endif
-
-        if (saveAsDefault) {
-            saveSelectedAsDefault ();
-        }
-
-        return true;
-    }
-
-    const int wasSelectedRow = m_selectedRow;
-    const int wasSelectedCol = m_selectedCol;
-
-    m_selectedRow = row;
-    m_selectedCol = col;
-
-    if (wasSelectedRow >= 0 && wasSelectedCol >= 0)
-    {
-        // unhighlight old option
-        update (m_pixmapRects [wasSelectedRow][wasSelectedCol]);
-    }
-
-    // highlight new option
-    update (m_pixmapRects [row][col]);
-
-#if DEBUG_KP_TOOL_WIDGET_BASE
-    qCDebug(kpLogWidgets) << "\tOK";
-#endif
-
-    if (saveAsDefault) {
-        saveSelectedAsDefault ();
-    }
-
-    Q_EMIT optionSelected (row, col);
-    return true;
-}
-
-//---------------------------------------------------------------------
-
-// public slot
-bool kpToolWidgetBase::setSelected (int row, int col)
-{
-    return setSelected (row, col, true/*set as default*/);
-}
-
-//---------------------------------------------------------------------
-
-
-// public slot
-bool kpToolWidgetBase::selectPreviousOption ()
-{
-    int newRow, newCol;
-    if (!hasPreviousOption (&newRow, &newCol)) {
-        return false;
-    }
-
-    return setSelected (newRow, newCol);
-}
-
-//---------------------------------------------------------------------
-
-// public slot
-bool kpToolWidgetBase::selectNextOption ()
-{
-    int newRow, newCol;
-    if (!hasNextOption (&newRow, &newCol)) {
-        return false;
-    }
-
-    return setSelected (newRow, newCol);
-}
-
-//---------------------------------------------------------------------
-
-
-// protected virtual [base QWidget]
-bool kpToolWidgetBase::event (QEvent *e)
-{
-    // TODO: It's unclear when we should call the base, call accept() and
-    //       return true or false.  Look at other event() handlers.  The
-    //       kpToolText one is wrong since after calling accept(), it calls
-    //       its base which calls ignore() :)
-    if (e->type () == QEvent::ToolTip)
-    {
-        auto *he = dynamic_cast<QHelpEvent *> (e);
-    #if DEBUG_KP_TOOL_WIDGET_BASE
-        qCDebug(kpLogWidgets) << "kpToolWidgetBase::event() QHelpEvent pos=" << he->pos ();
-    #endif
-
-        bool showedText = false;
-        for (int r = 0; r < m_pixmapRects.count (); r++)
-        {
-            for (int c = 0; c < m_pixmapRects [r].count (); c++)
-            {
-                if (m_pixmapRects [r][c].contains (he->pos ()))
-                {
-                    const QString tip = m_toolTips [r][c];
-                #if DEBUG_KP_TOOL_WIDGET_BASE
-                    qCDebug(kpLogWidgets) << "\tin option: r=" << r << "c=" << c
-                              << "tip='" << tip << "'";
-                #endif                
-                    if (!tip.isEmpty ())
-                    {
-                        QToolTip::showText (he->globalPos (), tip, this);
-                        showedText = true;
-                    }
-
-                    e->accept ();
-                    goto exit_loops;
-                }
-            }
-        }
-
-    exit_loops:
-        if (!showedText)
-        {
-        #if DEBUG_KP_TOOL_WIDGET_BASE
-            qCDebug(kpLogWidgets) << "\thiding text";
-        #endif
-            QToolTip::hideText ();
-        }
-
-        return true;
-    }
-
-    return QWidget::event (e);
-}
-
-//---------------------------------------------------------------------
-
-
-// protected virtual [base QWidget]
-void kpToolWidgetBase::mousePressEvent (QMouseEvent *e)
-{
-    e->ignore ();
-
-    if (e->button () != Qt::LeftButton) {
-        return;
-    }
-
-
-    for (int i = 0; i < m_pixmapRects.count (); i++)
-    {
-        for (int j = 0; j < m_pixmapRects [i].count (); j++)
-        {
-            if (m_pixmapRects [i][j].contains (e->pos ()))
-            {
-                setSelected (i, j);
-                e->accept ();
-                return;
-            }
-        }
-    }
-}
-
-//---------------------------------------------------------------------
-
-// protected virtual [base QWidget]
-void kpToolWidgetBase::paintEvent (QPaintEvent *e)
-{
-#if DEBUG_KP_TOOL_WIDGET_BASE && 1
-    qCDebug(kpLogWidgets) << "kpToolWidgetBase::paintEvent(): rect=" << contentsRect ();
-#endif
-
-    // Draw frame first.
-    QFrame::paintEvent (e);
-
-    QPainter painter (this);
-
-    for (int i = 0; i < m_pixmaps.count (); i++)
-    {
-        #if DEBUG_KP_TOOL_WIDGET_BASE && 1
-            qCDebug(kpLogWidgets) << "\tRow: " << i;
-        #endif
-
-        for (int j = 0; j < m_pixmaps [i].count (); j++)
-        {
-            QRect rect = m_pixmapRects [i][j];
-            QPixmap pixmap = m_pixmaps [i][j];
-
-        #if DEBUG_KP_TOOL_WIDGET_BASE && 1
-            qCDebug(kpLogWidgets) << "\t\tCol: " << j << " rect=" << rect;
-        #endif
-
-            if (i == m_selectedRow && j == m_selectedCol)
-            {
-                painter.fillRect(rect, palette().color(QPalette::Highlight).rgb());
-            }
-
-        #if DEBUG_KP_TOOL_WIDGET_BASE && 1
-            qCDebug(kpLogWidgets) << "\t\t\tdraw pixmap @ x="
-                       << rect.x () + (rect.width () - pixmap.width ()) / 2
-                       << " y="
-                       << rect.y () + (rect.height () - pixmap.height ()) / 2;
-
-        #endif
-
-            painter.drawPixmap(QPoint(rect.x () + (rect.width () - pixmap.width ()) / 2,
-                                      rect.y () + (rect.height () - pixmap.height ()) / 2),
-                               pixmap);
-        }
-    }
-}
-
-//---------------------------------------------------------------------
-
-#include "moc_kpToolWidgetBase.cpp"
+// //---------------------------------------------------------------------
+
+// kpToolWidgetBase::kpToolWidgetBase (QWidget *parent, const QString &name)
+//     : QFrame(parent), m_baseWidget(nullptr),
+//       m_selectedRow(-1), m_selectedCol(-1)
+// {
+//     setObjectName (name);
+
+//     setFrameStyle (QFrame::Panel | QFrame::Sunken);
+
+//     setFixedSize (44, 66);
+//     setSizePolicy (QSizePolicy::Minimum, QSizePolicy::Minimum);
+// }
+
+// //---------------------------------------------------------------------
+
+// kpToolWidgetBase::~kpToolWidgetBase () = default;
+
+// //---------------------------------------------------------------------
+
+// // public
+// void kpToolWidgetBase::addOption (const QPixmap &pixmap, const QString &toolTip)
+// {
+//     if (m_pixmaps.isEmpty ()) {
+//         startNewOptionRow ();
+//     }
+
+//     m_pixmaps.last ().append (pixmap);
+//     m_pixmapRects.last ().append (QRect ());
+//     m_toolTips.last ().append (toolTip);
+// }
+
+// //---------------------------------------------------------------------
+
+// // public
+// void kpToolWidgetBase::startNewOptionRow ()
+// {
+//     m_pixmaps.append (QList <QPixmap> ());
+//     m_pixmapRects.append (QList <QRect> ());
+//     m_toolTips.append (QList <QString> ());
+// }
+
+// //---------------------------------------------------------------------
+
+// // public
+// void kpToolWidgetBase::finishConstruction (int fallBackRow, int fallBackCol)
+// {
+// #if DEBUG_KP_TOOL_WIDGET_BASE
+//     qCDebug(kpLogWidgets) << "kpToolWidgetBase(" << objectName ()
+//                << ")::kpToolWidgetBase(fallBack:row=" << fallBackRow
+//                << ",col=" << fallBackCol
+//                << ")";
+// #endif
+
+//     relayoutOptions ();
+
+//     // HACK: Undo the maximum half of setFixedSize() in the ctor to avoid
+//     //       bizarre redraw errors when tool widgets are hidden and others
+//     //       are shown.
+//     //
+//     //       The reason why we didn't just use setMinimumSize() in the ctor is
+//     //       because all tool widgets construct pixmaps whose sizes are dependent
+//     //       on the size() in the ctor, so we needed to get the correct size
+//     //       in there.  This is bad design because it means that tool widgets
+//     //       can't really be resized.
+//     setMaximumSize (QWIDGETSIZE_MAX, QWIDGETSIZE_MAX);
+
+//     const QPair <int, int> rowColPair = defaultSelectedRowAndCol ();
+//     if (!setSelected (rowColPair.first, rowColPair.second, false/*don't save*/))
+//     {
+//         if (!setSelected (fallBackRow, fallBackCol))
+//         {
+//             if (!setSelected (0, 0))
+//             {
+//                 qCCritical(kpLogWidgets) << "kpToolWidgetBase::finishConstruction() "
+//                               "can't even fall back to setSelected(row=0,col=0)";
+//             }
+//         }
+//     }
+// }
+
+// //---------------------------------------------------------------------
+
+// // private
+// QList <int> kpToolWidgetBase::spreadOutElements (const QList <int> &sizes, int max)
+// {
+//     if (sizes.count () == 0) {
+//         return {};
+//     }
+
+//     if (sizes.count () == 1)
+//     {
+//         QList <int> ret;
+//         ret.append (sizes.first () > max ? 0 : 1/*margin*/);
+//         return ret;
+//     }
+
+//     QList <int> retOffsets;
+//     for (int i = 0; i < sizes.count (); i++) {
+//         retOffsets.append (0);
+//     }
+
+//     int totalSize = 0;
+//     for (int i = 0; i <  sizes.count (); i++) {
+//         totalSize += sizes [i];
+//     }
+
+//     int margin = 1;
+
+//     // if don't fit with margin, then just return elements
+//     // packed right next to each other
+//     if (totalSize + margin * 2 > max)
+//     {
+//         retOffsets [0] = 0;
+//         for (int i = 1; i < sizes.count (); i++) {
+//             retOffsets [i] = retOffsets [i - 1] + sizes [i - 1];
+//         }
+
+//         return retOffsets;
+//     }
+
+//     int maxLeftOver = max - (totalSize + margin * 2 * sizes.count());
+
+//     int startCompensating = -1;
+//     int numCompensate = 0;
+
+//     int spacing = 0;
+
+//     spacing = maxLeftOver / (sizes.count () - 1);
+//     if (spacing * int (sizes.count () - 1) < maxLeftOver)
+//     {
+//         numCompensate = maxLeftOver - spacing * (sizes.count () - 1);
+//         startCompensating = ((sizes.count () - 1) - numCompensate) / 2;
+//     }
+
+//     retOffsets [0] = margin;
+//     for (int i = 1; i < sizes.count (); i++)
+//     {
+//         retOffsets [i] += retOffsets [i - 1] +
+//                           sizes [i - 1] +
+//                           spacing +
+//                           ((numCompensate &&
+//                            i >= startCompensating &&
+//                            i < startCompensating + numCompensate) ? 1 : 0);
+//     }
+
+//     return retOffsets;
+// }
+
+// //---------------------------------------------------------------------
+
+// // public
+// QPair <int, int> kpToolWidgetBase::defaultSelectedRowAndCol () const
+// {
+//     int row = -1, col = -1;
+
+//     if (!objectName ().isEmpty ())
+//     {
+//         KConfigGroup cfg (KSharedConfig::openConfig (), QStringLiteral(kpSettingsGroupTools));
+
+//         row = cfg.readEntry (objectName () + QLatin1String (" Row"), -1);
+//         col = cfg.readEntry (objectName () + QLatin1String (" Col"), -1);
+//     }
+
+// #if DEBUG_KP_TOOL_WIDGET_BASE
+//     qCDebug(kpLogWidgets) << "kpToolWidgetBase(" << objectName ()
+//                << ")::defaultSelectedRowAndCol() returning row=" << row
+//                << " col=" << col;
+// #endif
+
+//     return qMakePair (row, col);
+// }
+
+// //---------------------------------------------------------------------
+
+// // public
+// int kpToolWidgetBase::defaultSelectedRow () const
+// {
+//     return defaultSelectedRowAndCol ().first;
+// }
+
+// //---------------------------------------------------------------------
+
+// // public
+// int kpToolWidgetBase::defaultSelectedCol () const
+// {
+//     return defaultSelectedRowAndCol ().second;
+// }
+
+// //---------------------------------------------------------------------
+
+// // public
+// void kpToolWidgetBase::saveSelectedAsDefault () const
+// {
+// #if DEBUG_KP_TOOL_WIDGET_BASE
+//     qCDebug(kpLogWidgets) << "kpToolWidgetBase(" << objectName ()
+//                << ")::saveSelectedAsDefault() row=" << m_selectedRow
+//                << " col=" << m_selectedCol;
+// #endif
+
+//     if (objectName ().isEmpty ()) {
+//         return;
+//     }
+
+//     KConfigGroup cfg (KSharedConfig::openConfig (), QStringLiteral(kpSettingsGroupTools));
+
+//     cfg.writeEntry (objectName () + QLatin1String (" Row"), m_selectedRow);
+//     cfg.writeEntry (objectName () + QLatin1String (" Col"), m_selectedCol);
+//     cfg.sync ();
+// }
+
+// //---------------------------------------------------------------------
+
+// // public
+// void kpToolWidgetBase::relayoutOptions ()
+// {
+// #if DEBUG_KP_TOOL_WIDGET_BASE
+//     qCDebug(kpLogWidgets) << "kpToolWidgetBase::relayoutOptions() size=" << size ();
+// #endif
+
+//     while (!m_pixmaps.isEmpty () && m_pixmaps.last ().count () == 0)
+//     {
+//     #if DEBUG_KP_TOOL_WIDGET_BASE
+//         qCDebug(kpLogWidgets) << "\tkilling #" << m_pixmaps.count () - 1;
+//     #endif
+//         m_pixmaps.removeLast ();
+//         m_pixmapRects.removeLast ();
+//         m_toolTips.removeLast ();
+//     }
+
+//     if (m_pixmaps.isEmpty ()) {
+//         return;
+//     }
+
+// #if DEBUG_KP_TOOL_WIDGET_BASE
+//     qCDebug(kpLogWidgets) << "\tsurvived killing of empty rows";
+//     qCDebug(kpLogWidgets) << "\tfinding heights of rows:";
+// #endif
+
+//     QList <int> maxHeightOfRow;
+//     for (int r = 0; r < m_pixmaps.count (); r++) {
+//         maxHeightOfRow.append (0);
+//     }
+
+//     for (int r = 0; r <  m_pixmaps.count (); r++)
+//     {
+//         for (int c = 0; c <  m_pixmaps [r].count (); c++)
+//         {
+//             if (c == 0 || m_pixmaps [r][c].height () > maxHeightOfRow [r]) {
+//                 maxHeightOfRow [r] = m_pixmaps [r][c].height ();
+//             }
+//         }
+//     #if DEBUG_KP_TOOL_WIDGET_BASE
+//         qCDebug(kpLogWidgets) << "\t\t" << r << ": " << maxHeightOfRow [r];
+//     #endif
+//     }
+
+//     QList <int> rowYOffset = spreadOutElements (maxHeightOfRow, height ());
+// #if DEBUG_KP_TOOL_WIDGET_BASE
+//     qCDebug(kpLogWidgets) << "\tspread out offsets of rows:";
+//     for (int r = 0; r < (int) rowYOffset.count (); r++) {
+//         qCDebug(kpLogWidgets) << "\t\t" << r << ": " << rowYOffset [r];
+//     }
+// #endif
+
+//     for (int r = 0; r < m_pixmaps.count (); r++)
+//     {
+//     #if DEBUG_KP_TOOL_WIDGET_BASE
+//         qCDebug(kpLogWidgets) << "\tlaying out row " << r << ":";
+//     #endif
+
+//         QList <int> widths;
+//         for (int c = 0; c < m_pixmaps [r].count (); c++)
+//             widths.append (m_pixmaps [r][c].width ());
+//     #if DEBUG_KP_TOOL_WIDGET_BASE
+//         qCDebug(kpLogWidgets) << "\t\twidths of cols:";
+//         for (int c = 0; c <  m_pixmaps [r].count (); c++) {
+//             qCDebug(kpLogWidgets) << "\t\t\t" << c << ": " << widths [c];
+//         }
+//     #endif
+
+//         QList <int> colXOffset = spreadOutElements (widths, width ());
+//     #if DEBUG_KP_TOOL_WIDGET_BASE
+//         qCDebug(kpLogWidgets) << "\t\tspread out offsets of cols:";
+//         for (int c = 0; c < colXOffset.count (); c++) {
+//             qCDebug(kpLogWidgets) << "\t\t\t" << c << ": " << colXOffset [c];
+//         }
+//     #endif
+
+//         for (int c = 0; c < colXOffset.count (); c++)
+//         {
+//             int x = colXOffset [c];
+//             int y = rowYOffset [r];
+//             int w, h;
+
+//             if (c == colXOffset.count () - 1)
+//             {
+//                 if (x + m_pixmaps [r][c].width () >= width ()) {
+//                     w = m_pixmaps [r][c].width ();
+//                 }
+//                 else {
+//                     w = width () - 1 - x;
+//                 }
+//             }
+//             else {
+//                 w = colXOffset [c + 1] - x;
+//             }
+
+//             if (r == m_pixmaps.count () - 1)
+//             {
+//                 if (y + m_pixmaps [r][c].height () >= height ()) {
+//                     h = m_pixmaps [r][c].height ();
+//                 }
+//                 else {
+//                     h = height () - 1 - y;
+//                 }
+//             }
+//             else {
+//                 h = rowYOffset [r + 1] - y;
+//             }
+
+//             m_pixmapRects [r][c] = QRect (x, y, w, h);
+//         }
+//     }
+
+//     update ();
+// }
+
+// //---------------------------------------------------------------------
+
+
+// // public
+// int kpToolWidgetBase::selectedRow () const
+// {
+//     return m_selectedRow;
+// }
+
+// //---------------------------------------------------------------------
+
+// // public
+// int kpToolWidgetBase::selectedCol () const
+// {
+//     return m_selectedCol;
+// }
+
+// //---------------------------------------------------------------------
+
+// // public
+// int kpToolWidgetBase::selected () const
+// {
+//     if (m_selectedRow < 0 ||
+//         m_selectedRow >= m_pixmaps.count () ||
+//         m_selectedCol < 0)
+//     {
+//         return -1;
+//     }
+
+//     int upto = 0;
+//     for (int y = 0; y < m_selectedRow; y++) {
+//         upto += m_pixmaps [y].count ();
+//     }
+
+//     if (m_selectedCol >= m_pixmaps [m_selectedRow].count ()) {
+//         return -1;
+//     }
+
+//     upto += m_selectedCol;
+
+//     return upto;
+// }
+
+// //---------------------------------------------------------------------
+
+
+// // public
+// bool kpToolWidgetBase::hasPreviousOption (int *row, int *col) const
+// {
+// #if DEBUG_KP_TOOL_WIDGET_BASE
+//     qCDebug(kpLogWidgets) << "kpToolWidgetBase(" << objectName ()
+//                << ")::hasPreviousOption() current row=" << m_selectedRow
+//                << " col=" << m_selectedCol;
+// #endif
+//     if (row) {
+//         *row = -1;
+//     }
+//     if (col) {
+//         *col = -1;
+//     }
+
+
+//     if (m_selectedRow < 0 || m_selectedCol < 0) {
+//         return false;
+//     }
+
+//     int newRow = m_selectedRow,
+//         newCol = m_selectedCol;
+
+//     newCol--;
+//     if (newCol < 0)
+//     {
+//         newRow--;
+//         if (newRow < 0) {
+//             return false;
+//         }
+
+//         newCol = m_pixmaps [newRow].count () - 1;
+//         if (newCol < 0) {
+//             return false;
+//         }
+//     }
+
+
+//     if (row) {
+//         *row = newRow;
+//     }
+//     if (col) {
+//         *col = newCol;
+//     }
+
+//     return true;
+// }
+
+// //---------------------------------------------------------------------
+
+// // public
+// bool kpToolWidgetBase::hasNextOption (int *row, int *col) const
+// {
+// #if DEBUG_KP_TOOL_WIDGET_BASE
+//     qCDebug(kpLogWidgets) << "kpToolWidgetBase(" << objectName ()
+//                << ")::hasNextOption() current row=" << m_selectedRow
+//                << " col=" << m_selectedCol;
+// #endif
+
+//     if (row) {
+//         *row = -1;
+//     }
+//     if (col) {
+//         *col = -1;
+//     }
+
+
+//     if (m_selectedRow < 0 || m_selectedCol < 0) {
+//         return false;
+//     }
+
+//     int newRow = m_selectedRow,
+//         newCol = m_selectedCol;
+
+//     newCol++;
+//     if (newCol >= m_pixmaps [newRow].count ())
+//     {
+//         newRow++;
+//         if (newRow >= m_pixmaps.count ()) {
+//             return false;
+//         }
+
+//         newCol = 0;
+//         if (newCol >= m_pixmaps [newRow].count ()) {
+//             return false;
+//         }
+//     }
+
+
+//     if (row) {
+//         *row = newRow;
+//     }
+//     if (col) {
+//         *col = newCol;
+//     }
+
+//     return true;
+// }
+
+// //---------------------------------------------------------------------
+
+
+// // public slot virtual
+// bool kpToolWidgetBase::setSelected (int row, int col, bool saveAsDefault)
+// {
+// #if DEBUG_KP_TOOL_WIDGET_BASE
+//     qCDebug(kpLogWidgets) << "kpToolWidgetBase::setSelected(row=" << row
+//                << ",col=" << col
+//                << ",saveAsDefault=" << saveAsDefault
+//                << ")";
+// #endif
+
+//     if (row < 0 || col < 0 ||
+//         row >= m_pixmapRects.count () || col >= m_pixmapRects [row].count ())
+//     {
+//     #if DEBUG_KP_TOOL_WIDGET_BASE
+//         qCDebug(kpLogWidgets) << "\tout of range";
+//     #endif
+//         return false;
+//     }
+
+//     if (row == m_selectedRow && col == m_selectedCol)
+//     {
+//     #if DEBUG_KP_TOOL_WIDGET_BASE
+//         qCDebug(kpLogWidgets) << "\tNOP";
+//     #endif
+
+//         if (saveAsDefault) {
+//             saveSelectedAsDefault ();
+//         }
+
+//         return true;
+//     }
+
+//     const int wasSelectedRow = m_selectedRow;
+//     const int wasSelectedCol = m_selectedCol;
+
+//     m_selectedRow = row;
+//     m_selectedCol = col;
+
+//     if (wasSelectedRow >= 0 && wasSelectedCol >= 0)
+//     {
+//         // unhighlight old option
+//         update (m_pixmapRects [wasSelectedRow][wasSelectedCol]);
+//     }
+
+//     // highlight new option
+//     update (m_pixmapRects [row][col]);
+
+// #if DEBUG_KP_TOOL_WIDGET_BASE
+//     qCDebug(kpLogWidgets) << "\tOK";
+// #endif
+
+//     if (saveAsDefault) {
+//         saveSelectedAsDefault ();
+//     }
+
+//     Q_EMIT optionSelected (row, col);
+//     return true;
+// }
+
+// //---------------------------------------------------------------------
+
+// // public slot
+// bool kpToolWidgetBase::setSelected (int row, int col)
+// {
+//     return setSelected (row, col, true/*set as default*/);
+// }
+
+// //---------------------------------------------------------------------
+
+
+// // public slot
+// bool kpToolWidgetBase::selectPreviousOption ()
+// {
+//     int newRow, newCol;
+//     if (!hasPreviousOption (&newRow, &newCol)) {
+//         return false;
+//     }
+
+//     return setSelected (newRow, newCol);
+// }
+
+// //---------------------------------------------------------------------
+
+// // public slot
+// bool kpToolWidgetBase::selectNextOption ()
+// {
+//     int newRow, newCol;
+//     if (!hasNextOption (&newRow, &newCol)) {
+//         return false;
+//     }
+
+//     return setSelected (newRow, newCol);
+// }
+
+// //---------------------------------------------------------------------
+
+
+// // protected virtual [base QWidget]
+// bool kpToolWidgetBase::event (QEvent *e)
+// {
+//     // TODO: It's unclear when we should call the base, call accept() and
+//     //       return true or false.  Look at other event() handlers.  The
+//     //       kpToolText one is wrong since after calling accept(), it calls
+//     //       its base which calls ignore() :)
+//     if (e->type () == QEvent::ToolTip)
+//     {
+//         auto *he = dynamic_cast<QHelpEvent *> (e);
+//     #if DEBUG_KP_TOOL_WIDGET_BASE
+//         qCDebug(kpLogWidgets) << "kpToolWidgetBase::event() QHelpEvent pos=" << he->pos ();
+//     #endif
+
+//         bool showedText = false;
+//         for (int r = 0; r < m_pixmapRects.count (); r++)
+//         {
+//             for (int c = 0; c < m_pixmapRects [r].count (); c++)
+//             {
+//                 if (m_pixmapRects [r][c].contains (he->pos ()))
+//                 {
+//                     const QString tip = m_toolTips [r][c];
+//                 #if DEBUG_KP_TOOL_WIDGET_BASE
+//                     qCDebug(kpLogWidgets) << "\tin option: r=" << r << "c=" << c
+//                               << "tip='" << tip << "'";
+//                 #endif                
+//                     if (!tip.isEmpty ())
+//                     {
+//                         QToolTip::showText (he->globalPos (), tip, this);
+//                         showedText = true;
+//                     }
+
+//                     e->accept ();
+//                     goto exit_loops;
+//                 }
+//             }
+//         }
+
+//     exit_loops:
+//         if (!showedText)
+//         {
+//         #if DEBUG_KP_TOOL_WIDGET_BASE
+//             qCDebug(kpLogWidgets) << "\thiding text";
+//         #endif
+//             QToolTip::hideText ();
+//         }
+
+//         return true;
+//     }
+
+//     return QWidget::event (e);
+// }
+
+// //---------------------------------------------------------------------
+
+
+// // protected virtual [base QWidget]
+// void kpToolWidgetBase::mousePressEvent (QMouseEvent *e)
+// {
+//     e->ignore ();
+
+//     if (e->button () != Qt::LeftButton) {
+//         return;
+//     }
+
+
+//     for (int i = 0; i < m_pixmapRects.count (); i++)
+//     {
+//         for (int j = 0; j < m_pixmapRects [i].count (); j++)
+//         {
+//             if (m_pixmapRects [i][j].contains (e->pos ()))
+//             {
+//                 setSelected (i, j);
+//                 e->accept ();
+//                 return;
+//             }
+//         }
+//     }
+// }
+
+// //---------------------------------------------------------------------
+
+// // protected virtual [base QWidget]
+// void kpToolWidgetBase::paintEvent (QPaintEvent *e)
+// {
+// #if DEBUG_KP_TOOL_WIDGET_BASE && 1
+//     qCDebug(kpLogWidgets) << "kpToolWidgetBase::paintEvent(): rect=" << contentsRect ();
+// #endif
+
+//     // Draw frame first.
+//     QFrame::paintEvent (e);
+
+//     QPainter painter (this);
+
+//     for (int i = 0; i < m_pixmaps.count (); i++)
+//     {
+//         #if DEBUG_KP_TOOL_WIDGET_BASE && 1
+//             qCDebug(kpLogWidgets) << "\tRow: " << i;
+//         #endif
+
+//         for (int j = 0; j < m_pixmaps [i].count (); j++)
+//         {
+//             QRect rect = m_pixmapRects [i][j];
+//             QPixmap pixmap = m_pixmaps [i][j];
+
+//         #if DEBUG_KP_TOOL_WIDGET_BASE && 1
+//             qCDebug(kpLogWidgets) << "\t\tCol: " << j << " rect=" << rect;
+//         #endif
+
+//             if (i == m_selectedRow && j == m_selectedCol)
+//             {
+//                 painter.fillRect(rect, palette().color(QPalette::Highlight).rgb());
+//             }
+
+//         #if DEBUG_KP_TOOL_WIDGET_BASE && 1
+//             qCDebug(kpLogWidgets) << "\t\t\tdraw pixmap @ x="
+//                        << rect.x () + (rect.width () - pixmap.width ()) / 2
+//                        << " y="
+//                        << rect.y () + (rect.height () - pixmap.height ()) / 2;
+
+//         #endif
+
+//             painter.drawPixmap(QPoint(rect.x () + (rect.width () - pixmap.width ()) / 2,
+//                                       rect.y () + (rect.height () - pixmap.height ()) / 2),
+//                                pixmap);
+//         }
+//     }
+// }
+
+// //---------------------------------------------------------------------
+
+// #include "moc_kpToolWidgetBase.cpp"

--- a/widgets/toolbars/options/kpToolWidgetBase.h
+++ b/widgets/toolbars/options/kpToolWidgetBase.h
@@ -37,13 +37,15 @@
 #include <QList>
 #include <QWidget>
 
+#include <SARibbonBar/SARibbonGallery.h>
+#include <SARibbonBar/SARibbonGalleryGroup.h>
 
 class QMouseEvent;
 
 
 // TODO: This is a crazy and overcomplicated class that invents its own (buggy)
 //       layout management.  It should be simplified or removed.
-class kpToolWidgetBase : public QFrame
+class kpToolWidgetBase : public SARibbonGallery
 {
 Q_OBJECT
 
@@ -51,12 +53,6 @@ public:
     // (must provide a <name> for config to work)
     kpToolWidgetBase (QWidget *parent, const QString &name);
     ~kpToolWidgetBase () override;
-
-protected:
-    kpToolWidgetBase (QWidget *parent) :
-        QFrame(parent)
-    {
-    }
 
 public:
     void addOption (const QPixmap &pixmap, const QString &toolTip = QString());
@@ -101,11 +97,6 @@ Q_SIGNALS:
     void optionSelected (int row, int col);
 
 protected:
-    bool event (QEvent *e) override;
- 
-    void mousePressEvent (QMouseEvent *e) override;
-    void paintEvent (QPaintEvent *e) override;
-
     QWidget *m_baseWidget;
 
     QList < QList <QPixmap> > m_pixmaps;
@@ -114,73 +105,12 @@ protected:
     QList < QList <QRect> > m_pixmapRects;
 
     int m_selectedRow, m_selectedCol;
-};
-
-#include <SARibbonBar/SARibbonGallery.h>
-#include <SARibbonBar/SARibbonGalleryGroup.h>
-
-class kpToolWidgetBase_Ribbon : public kpToolWidgetBase
-{
-Q_OBJECT
-
-public:
-    // (must provide a <name> for config to work)
-    kpToolWidgetBase_Ribbon (QWidget *parent, const QString &name);
-    ~kpToolWidgetBase_Ribbon () override;
-
-public:
-    void addOption (const QPixmap &pixmap, const QString &toolTip = QString());
-    void startNewOptionRow ();
-
-    // Call this at the end of your constructor.
-    // If the default row & col could not be read from the config,
-    // <fallBackRow> & <fallBackCol> are passed to setSelected().
-    void finishConstruction (int fallBackRow, int fallBackCol);
-
-private:
-    QList <int> spreadOutElements (const QList <int> &sizes, int maxSize);
-
-public:  // (only have to use these if you don't use finishConstruction())
-    // (rereads from config file)
-    QPair <int, int> defaultSelectedRowAndCol () const;
-    int defaultSelectedRow () const;
-    int defaultSelectedCol () const;
-
-    void saveSelectedAsDefault () const;
-
-    void relayoutOptions ();
-
-public:
-    int selectedRow () const;
-    int selectedCol () const;
-
-    int selected () const;
-
-    bool hasPreviousOption (int *row = nullptr, int *col = nullptr) const;
-    bool hasNextOption (int *row = nullptr, int *col = nullptr) const;
-
-public Q_SLOTS:
-    bool setSelected (int row, int col, bool saveAsDefault) override;
-    bool setSelected (int row, int col);
-
-    bool selectPreviousOption ();
-    bool selectNextOption ();
-
-protected:
-    bool event (QEvent *e) override;
- 
-    void mousePressEvent (QMouseEvent *e) override;
-    void paintEvent (QPaintEvent *e) override;
-
-    ////////////////
 
 private Q_SLOTS:
     void callOptionSelected();
 
 private:
-    SARibbonGallery *m_gallery;
     SARibbonGalleryGroup *m_galleryGroup;
 };
-
 
 #endif  // KP_TOOL_WIDGET_BASE_H

--- a/widgets/toolbars/options/kpToolWidgetBase.h
+++ b/widgets/toolbars/options/kpToolWidgetBase.h
@@ -52,6 +52,12 @@ public:
     kpToolWidgetBase (QWidget *parent, const QString &name);
     ~kpToolWidgetBase () override;
 
+protected:
+    kpToolWidgetBase (QWidget *parent) :
+        QFrame(parent)
+    {
+    }
+
 public:
     void addOption (const QPixmap &pixmap, const QString &toolTip = QString());
     void startNewOptionRow ();
@@ -108,6 +114,72 @@ protected:
     QList < QList <QRect> > m_pixmapRects;
 
     int m_selectedRow, m_selectedCol;
+};
+
+#include <SARibbonBar/SARibbonGallery.h>
+#include <SARibbonBar/SARibbonGalleryGroup.h>
+
+class kpToolWidgetBase_Ribbon : public kpToolWidgetBase
+{
+Q_OBJECT
+
+public:
+    // (must provide a <name> for config to work)
+    kpToolWidgetBase_Ribbon (QWidget *parent, const QString &name);
+    ~kpToolWidgetBase_Ribbon () override;
+
+public:
+    void addOption (const QPixmap &pixmap, const QString &toolTip = QString());
+    void startNewOptionRow ();
+
+    // Call this at the end of your constructor.
+    // If the default row & col could not be read from the config,
+    // <fallBackRow> & <fallBackCol> are passed to setSelected().
+    void finishConstruction (int fallBackRow, int fallBackCol);
+
+private:
+    QList <int> spreadOutElements (const QList <int> &sizes, int maxSize);
+
+public:  // (only have to use these if you don't use finishConstruction())
+    // (rereads from config file)
+    QPair <int, int> defaultSelectedRowAndCol () const;
+    int defaultSelectedRow () const;
+    int defaultSelectedCol () const;
+
+    void saveSelectedAsDefault () const;
+
+    void relayoutOptions ();
+
+public:
+    int selectedRow () const;
+    int selectedCol () const;
+
+    int selected () const;
+
+    bool hasPreviousOption (int *row = nullptr, int *col = nullptr) const;
+    bool hasNextOption (int *row = nullptr, int *col = nullptr) const;
+
+public Q_SLOTS:
+    bool setSelected (int row, int col, bool saveAsDefault) override;
+    bool setSelected (int row, int col);
+
+    bool selectPreviousOption ();
+    bool selectNextOption ();
+
+protected:
+    bool event (QEvent *e) override;
+ 
+    void mousePressEvent (QMouseEvent *e) override;
+    void paintEvent (QPaintEvent *e) override;
+
+    ////////////////
+
+private Q_SLOTS:
+    void callOptionSelected();
+
+private:
+    SARibbonGallery *m_gallery;
+    SARibbonGalleryGroup *m_galleryGroup;
 };
 
 

--- a/widgets/toolbars/options/kpToolWidgetBase_ribbon.cpp
+++ b/widgets/toolbars/options/kpToolWidgetBase_ribbon.cpp
@@ -1,0 +1,196 @@
+#include "kpToolWidgetBase.h"
+
+#include "kpDefs.h"
+
+#include <KConfig>
+#include <KConfigGroup>
+#include <KSharedConfig>
+#include "kpLogCategories.h"
+
+#include <QItemSelectionModel>
+
+kpToolWidgetBase_Ribbon::kpToolWidgetBase_Ribbon (QWidget *parent, const QString &name) :
+    kpToolWidgetBase(parent)
+{
+    m_gallery = new SARibbonGallery(this);
+    m_gallery->setSizePolicy (QSizePolicy::Maximum, QSizePolicy::Maximum);
+    m_galleryGroup = m_gallery->addGalleryGroup();
+
+    m_galleryGroup->setupGroupModel();
+
+    connect(m_galleryGroup->selectionModel(), &QItemSelectionModel::selectionChanged, this, &kpToolWidgetBase_Ribbon::callOptionSelected);
+
+    setObjectName (name);
+}
+
+kpToolWidgetBase_Ribbon::~kpToolWidgetBase_Ribbon () = default;
+
+void kpToolWidgetBase_Ribbon::addOption (const QPixmap &pixmap, const QString &toolTip)
+{
+    m_galleryGroup->addItem(toolTip, pixmap);
+}
+
+void kpToolWidgetBase_Ribbon::startNewOptionRow ()
+{
+    Q_ASSERT(false);    // Code that hasn't been refactored away from using this function will crash. Even if it thinks it's using the old brush selection widget, it must treat it as a 1d widget and not a 2d widget.
+}
+
+void kpToolWidgetBase_Ribbon::finishConstruction (int fallBackRow, int fallBackCol)
+{
+}
+
+QPair <int, int> kpToolWidgetBase_Ribbon::defaultSelectedRowAndCol () const
+{
+    return qMakePair(0, 0);
+}
+
+int kpToolWidgetBase_Ribbon::defaultSelectedRow () const
+{
+    return defaultSelectedRowAndCol ().first;
+}
+
+int kpToolWidgetBase_Ribbon::defaultSelectedCol () const
+{
+    return defaultSelectedRowAndCol ().second;
+}
+
+void kpToolWidgetBase_Ribbon::saveSelectedAsDefault () const
+{
+    if (objectName ().isEmpty ()) {
+        return;
+    }
+
+    KConfigGroup cfg (KSharedConfig::openConfig (), QStringLiteral(kpSettingsGroupTools));
+
+    cfg.writeEntry (objectName () + QLatin1String (" Row"), m_selectedRow);
+    cfg.writeEntry (objectName () + QLatin1String (" Col"), m_selectedCol);
+    cfg.sync ();
+}
+
+void kpToolWidgetBase_Ribbon::relayoutOptions ()
+{
+}
+
+int kpToolWidgetBase_Ribbon::selectedRow () const
+{
+    return this->selected();
+}
+
+int kpToolWidgetBase_Ribbon::selectedCol () const
+{
+    return 0;
+}
+
+int kpToolWidgetBase_Ribbon::selected () const
+{
+    if (m_galleryGroup->selectionModel()->selectedIndexes().count() > 0)
+        return m_galleryGroup->selectionModel()->selectedIndexes().at(0).row();
+    else
+        return -1;
+}
+
+bool kpToolWidgetBase_Ribbon::hasPreviousOption (int *row, int *col) const
+{
+    int sel = this->selected();
+
+    if (sel == -1 || sel == 0)
+    {
+        *row = *col = -1;
+        return false;
+    }
+    else
+    {
+        *row = sel - 1;
+        *col = 0;
+        return true;
+    }
+}
+
+bool kpToolWidgetBase_Ribbon::hasNextOption (int *row, int *col) const
+{
+    int sel = selected();
+    int count = m_galleryGroup->groupModel()->rowCount(QModelIndex());
+
+    if (sel == -1 || sel == count - 1)
+    {
+        *row = *col = -1;
+        return false;
+    }
+    else
+    {
+        *row = sel + 1;
+        *col = 0;
+        return true;
+    }
+}
+
+// public slot virtual
+bool kpToolWidgetBase_Ribbon::setSelected (int row, int col, bool saveAsDefault)
+{
+    setSelected(row, col);
+
+    if (saveAsDefault)
+        saveSelectedAsDefault();
+
+    return true;
+}
+
+// public slot
+bool kpToolWidgetBase_Ribbon::setSelected (int row, int col)
+{
+    m_galleryGroup->selectionModel()->clearSelection();
+    m_galleryGroup->selectionModel()->select(
+        m_galleryGroup->groupModel()->index(row, col, QModelIndex()),
+        QItemSelectionModel::Select
+    );
+
+    Q_EMIT optionSelected(row, col);
+
+    return true;
+}
+
+// public slot
+bool kpToolWidgetBase_Ribbon::selectPreviousOption ()
+{
+    int newRow, newCol;
+    if (!hasPreviousOption (&newRow, &newCol)) {
+        return false;
+    }
+
+    return setSelected (newRow, newCol);
+}
+
+// public slot
+bool kpToolWidgetBase_Ribbon::selectNextOption ()
+{
+    int newRow, newCol;
+    if (!hasNextOption (&newRow, &newCol)) {
+        return false;
+    }
+
+    return setSelected (newRow, newCol);
+}
+
+void kpToolWidgetBase_Ribbon::callOptionSelected()
+{
+    Q_EMIT optionSelected(selectedRow(), selectedCol());
+}
+
+// protected virtual [base QWidget]
+bool kpToolWidgetBase_Ribbon::event (QEvent *e)
+{
+    return QWidget::event (e);
+}
+
+// protected virtual [base QWidget]
+void kpToolWidgetBase_Ribbon::mousePressEvent (QMouseEvent *e)
+{
+    // delete me
+}
+
+// protected virtual [base QWidget]
+void kpToolWidgetBase_Ribbon::paintEvent (QPaintEvent *e)
+{
+    // Draw frame first.
+    QFrame::paintEvent (e);
+}

--- a/widgets/toolbars/options/kpToolWidgetBase_ribbon.cpp
+++ b/widgets/toolbars/options/kpToolWidgetBase_ribbon.cpp
@@ -9,52 +9,55 @@
 
 #include <QItemSelectionModel>
 
-kpToolWidgetBase_Ribbon::kpToolWidgetBase_Ribbon (QWidget *parent, const QString &name) :
-    kpToolWidgetBase(parent)
+kpToolWidgetBase::kpToolWidgetBase (QWidget *parent, const QString &name) :
+    SARibbonGallery(parent)
 {
-    m_gallery = new SARibbonGallery(this);
-    m_gallery->setSizePolicy (QSizePolicy::Maximum, QSizePolicy::Maximum);
-    m_galleryGroup = m_gallery->addGalleryGroup();
+    // m_gallery->setSizePolicy (QSizePolicy::Maximum, QSizePolicy::Maximum);
+    m_galleryGroup = SARibbonGallery::addGalleryGroup();
+    m_galleryGroup->setGroupTitle(name);
+    // m_galleryGroup->setDisplayRow(SARibbonGalleryGroup::DisplayRow::DisplayTwoRow);
 
     m_galleryGroup->setupGroupModel();
 
-    connect(m_galleryGroup->selectionModel(), &QItemSelectionModel::selectionChanged, this, &kpToolWidgetBase_Ribbon::callOptionSelected);
+    connect(this, &SARibbonGallery::triggered, this, &kpToolWidgetBase::callOptionSelected);
+    // connect(m_galleryGroup->selectionModel(), &QItemSelectionModel::selectionChanged, this, &kpToolWidgetBase::callOptionSelected);
 
     setObjectName (name);
 }
 
-kpToolWidgetBase_Ribbon::~kpToolWidgetBase_Ribbon () = default;
+kpToolWidgetBase::~kpToolWidgetBase () = default;
 
-void kpToolWidgetBase_Ribbon::addOption (const QPixmap &pixmap, const QString &toolTip)
+void kpToolWidgetBase::addOption (const QPixmap &pixmap, const QString &toolTip)
 {
     m_galleryGroup->addItem(toolTip, pixmap);
+    m_galleryGroup->recalcGridSize();
 }
 
-void kpToolWidgetBase_Ribbon::startNewOptionRow ()
+void kpToolWidgetBase::startNewOptionRow ()
 {
     Q_ASSERT(false);    // Code that hasn't been refactored away from using this function will crash. Even if it thinks it's using the old brush selection widget, it must treat it as a 1d widget and not a 2d widget.
 }
 
-void kpToolWidgetBase_Ribbon::finishConstruction (int fallBackRow, int fallBackCol)
+void kpToolWidgetBase::finishConstruction (int fallBackRow, int fallBackCol)
 {
 }
 
-QPair <int, int> kpToolWidgetBase_Ribbon::defaultSelectedRowAndCol () const
+QPair <int, int> kpToolWidgetBase::defaultSelectedRowAndCol () const
 {
     return qMakePair(0, 0);
 }
 
-int kpToolWidgetBase_Ribbon::defaultSelectedRow () const
+int kpToolWidgetBase::defaultSelectedRow () const
 {
     return defaultSelectedRowAndCol ().first;
 }
 
-int kpToolWidgetBase_Ribbon::defaultSelectedCol () const
+int kpToolWidgetBase::defaultSelectedCol () const
 {
     return defaultSelectedRowAndCol ().second;
 }
 
-void kpToolWidgetBase_Ribbon::saveSelectedAsDefault () const
+void kpToolWidgetBase::saveSelectedAsDefault () const
 {
     if (objectName ().isEmpty ()) {
         return;
@@ -67,65 +70,82 @@ void kpToolWidgetBase_Ribbon::saveSelectedAsDefault () const
     cfg.sync ();
 }
 
-void kpToolWidgetBase_Ribbon::relayoutOptions ()
+void kpToolWidgetBase::relayoutOptions ()
 {
 }
 
-int kpToolWidgetBase_Ribbon::selectedRow () const
+int kpToolWidgetBase::selectedRow () const
 {
     return this->selected();
 }
 
-int kpToolWidgetBase_Ribbon::selectedCol () const
+int kpToolWidgetBase::selectedCol () const
 {
     return 0;
 }
 
-int kpToolWidgetBase_Ribbon::selected () const
+int kpToolWidgetBase::selected () const
 {
+    fprintf(stderr, "\tn selected: %d\n", m_galleryGroup->selectionModel()->selectedIndexes().count());
+
     if (m_galleryGroup->selectionModel()->selectedIndexes().count() > 0)
+    {
+        fprintf(stderr, "\t          : %d\n", m_galleryGroup->selectionModel()->selectedIndexes().at(0).row());
         return m_galleryGroup->selectionModel()->selectedIndexes().at(0).row();
+    }
     else
-        return -1;
+        return /*-1*/0;
 }
 
-bool kpToolWidgetBase_Ribbon::hasPreviousOption (int *row, int *col) const
+bool kpToolWidgetBase::hasPreviousOption (int *row, int *col) const
 {
     int sel = this->selected();
 
     if (sel == -1 || sel == 0)
     {
-        *row = *col = -1;
+        if (row)
+            *row = -1;
+        if (col)
+            *col = -1;
+
         return false;
     }
     else
     {
-        *row = sel - 1;
-        *col = 0;
+        if (row)
+            *row = sel - 1;
+        if (col)
+            *col = 0;
         return true;
     }
 }
 
-bool kpToolWidgetBase_Ribbon::hasNextOption (int *row, int *col) const
+bool kpToolWidgetBase::hasNextOption (int *row, int *col) const
 {
     int sel = selected();
     int count = m_galleryGroup->groupModel()->rowCount(QModelIndex());
 
     if (sel == -1 || sel == count - 1)
     {
-        *row = *col = -1;
+        if (row)
+            *row = -1;
+        if (col)
+            *col = -1;
         return false;
     }
     else
     {
-        *row = sel + 1;
-        *col = 0;
+        if (row)
+            *row = sel + 1;
+        if (col)
+            *col = 0;
+
         return true;
     }
 }
 
 // public slot virtual
-bool kpToolWidgetBase_Ribbon::setSelected (int row, int col, bool saveAsDefault)
+bool kpToolWidgetBase::setSelected (int row, int col, bool saveAsDefault)
 {
     setSelected(row, col);
 
@@ -136,7 +156,7 @@ bool kpToolWidgetBase_Ribbon::setSelected (int row, int col, bool saveAsDefault)
 }
 
 // public slot
-bool kpToolWidgetBase_Ribbon::setSelected (int row, int col)
+bool kpToolWidgetBase::setSelected (int row, int col)
 {
     m_galleryGroup->selectionModel()->clearSelection();
     m_galleryGroup->selectionModel()->select(
@@ -150,7 +170,7 @@ bool kpToolWidgetBase_Ribbon::setSelected (int row, int col)
 }
 
 // public slot
-bool kpToolWidgetBase_Ribbon::selectPreviousOption ()
+bool kpToolWidgetBase::selectPreviousOption ()
 {
     int newRow, newCol;
     if (!hasPreviousOption (&newRow, &newCol)) {
@@ -161,7 +181,7 @@ bool kpToolWidgetBase_Ribbon::selectPreviousOption ()
 }
 
 // public slot
-bool kpToolWidgetBase_Ribbon::selectNextOption ()
+bool kpToolWidgetBase::selectNextOption ()
 {
     int newRow, newCol;
     if (!hasNextOption (&newRow, &newCol)) {
@@ -171,26 +191,9 @@ bool kpToolWidgetBase_Ribbon::selectNextOption ()
     return setSelected (newRow, newCol);
 }
 
-void kpToolWidgetBase_Ribbon::callOptionSelected()
+void kpToolWidgetBase::callOptionSelected()
 {
     Q_EMIT optionSelected(selectedRow(), selectedCol());
 }
 
-// protected virtual [base QWidget]
-bool kpToolWidgetBase_Ribbon::event (QEvent *e)
-{
-    return QWidget::event (e);
-}
 
-// protected virtual [base QWidget]
-void kpToolWidgetBase_Ribbon::mousePressEvent (QMouseEvent *e)
-{
-    // delete me
-}
-
-// protected virtual [base QWidget]
-void kpToolWidgetBase_Ribbon::paintEvent (QPaintEvent *e)
-{
-    // Draw frame first.
-    QFrame::paintEvent (e);
-}

--- a/widgets/toolbars/options/kpToolWidgetBase_ribbon.cpp
+++ b/widgets/toolbars/options/kpToolWidgetBase_ribbon.cpp
@@ -17,11 +17,6 @@ kpToolWidgetBase::kpToolWidgetBase (QWidget *parent, const QString &name) :
     m_galleryGroup->setGroupTitle(name);
     // m_galleryGroup->setDisplayRow(SARibbonGalleryGroup::DisplayRow::DisplayTwoRow);
 
-    m_galleryGroup->setupGroupModel();
-
-    connect(this, &SARibbonGallery::triggered, this, &kpToolWidgetBase::callOptionSelected);
-    // connect(m_galleryGroup->selectionModel(), &QItemSelectionModel::selectionChanged, this, &kpToolWidgetBase::callOptionSelected);
-
     setObjectName (name);
 }
 
@@ -30,7 +25,6 @@ kpToolWidgetBase::~kpToolWidgetBase () = default;
 void kpToolWidgetBase::addOption (const QPixmap &pixmap, const QString &toolTip)
 {
     m_galleryGroup->addItem(toolTip, pixmap);
-    m_galleryGroup->recalcGridSize();
 }
 
 void kpToolWidgetBase::startNewOptionRow ()
@@ -40,6 +34,8 @@ void kpToolWidgetBase::startNewOptionRow ()
 
 void kpToolWidgetBase::finishConstruction (int fallBackRow, int fallBackCol)
 {
+    // connect(this, &SARibbonGallery::triggered, this, &kpToolWidgetBase::callOptionSelected);
+    connect(m_galleryGroup->selectionModel(), &QItemSelectionModel::currentChanged, this, &kpToolWidgetBase::callOptionSelected);
 }
 
 QPair <int, int> kpToolWidgetBase::defaultSelectedRowAndCol () const
@@ -193,6 +189,7 @@ bool kpToolWidgetBase::selectNextOption ()
 
 void kpToolWidgetBase::callOptionSelected()
 {
+    fprintf(stderr, "callOptionSelected\n");
     Q_EMIT optionSelected(selectedRow(), selectedCol());
 }
 

--- a/widgets/toolbars/options/kpToolWidgetBrush.cpp
+++ b/widgets/toolbars/options/kpToolWidgetBrush.cpp
@@ -65,7 +65,7 @@ static void Draw (kpImage *destImage, const QPoint &topLeft, void *userData)
               << topLeft << " pack: row=" << pack->row << " col=" << pack->col
               << " color=" << (int *) pack->color.toQRgb ();
 #endif
-    const int size = ::BrushSizes [pack->row][pack->col];
+    const int size = ::BrushSizes [0][pack->row];
 #if DEBUG_KP_TOOL_WIDGET_BRUSH
     qCDebug(kpLogWidgets) << "\tsize=" << size;
 #endif
@@ -177,8 +177,6 @@ kpToolWidgetBrush::kpToolWidgetBrush (QWidget *parent, const QString &name)
             addOption(QPixmap::fromImage(std::move(previewPixmap)),
                       brushName(shape, i) /*tooltip*/);
         }
-
-        startNewOptionRow ();
     }
 
     finishConstruction (0, 0);
@@ -232,7 +230,7 @@ QString kpToolWidgetBrush::brushName (int shape, int whichSize) const
 // public
 int kpToolWidgetBrush::brushSize () const
 {
-    return ::BrushSizes [selectedRow ()][selectedCol ()];
+    return ::BrushSizes [0][selectedRow ()];
 }
 
 //---------------------------------------------------------------------
@@ -241,7 +239,7 @@ int kpToolWidgetBrush::brushSize () const
 bool kpToolWidgetBrush::brushIsDiagonalLine () const
 {
     // sync: <brushes>
-    return (selectedRow () >= 2);
+    return ((selectedRow () / BRUSH_SIZE_NUM_COLS) >= 2);
 }
 
 //---------------------------------------------------------------------

--- a/widgets/toolbars/options/kpToolWidgetBrush.cpp
+++ b/widgets/toolbars/options/kpToolWidgetBrush.cpp
@@ -65,7 +65,7 @@ static void Draw (kpImage *destImage, const QPoint &topLeft, void *userData)
               << topLeft << " pack: row=" << pack->row << " col=" << pack->col
               << " color=" << (int *) pack->color.toQRgb ();
 #endif
-    const int size = ::BrushSizes [0][pack->row];
+    const int size = ::BrushSizes [pack->row][pack->col];   // The ribbon UI perceives the brush list as 1D
 #if DEBUG_KP_TOOL_WIDGET_BRUSH
     qCDebug(kpLogWidgets) << "\tsize=" << size;
 #endif
@@ -80,7 +80,7 @@ static void Draw (kpImage *destImage, const QPoint &topLeft, void *userData)
     }
 
     // sync: <brushes>
-    switch (pack->row/*shape*/)
+    switch (pack->row /*shape*/)
     {
       case 0:
       {
@@ -159,12 +159,13 @@ kpToolWidgetBrush::kpToolWidgetBrush (QWidget *parent, const QString &name)
         {
             const int s = ::BrushSizes [shape][i];
 
-
-            const int w = (width () - 2/*margin*/ - 2/*spacing*/)
-                / BRUSH_SIZE_NUM_COLS;
-            const int h = (height () - 2/*margin*/ - 3/*spacing*/)
-                / BRUSH_SIZE_NUM_ROWS;
-            Q_ASSERT (w >= s && h >= s);
+            // const int w = (width () - 2/*margin*/ - 2/*spacing*/)
+            //     / BRUSH_SIZE_NUM_COLS;
+            // const int h = (height () - 2/*margin*/ - 3/*spacing*/)
+            //     / BRUSH_SIZE_NUM_ROWS;
+            const int w = 48;
+            const int h = 48;
+            // Q_ASSERT (w >= s && h >= s);
             QImage previewPixmap (w, h, QImage::Format_ARGB32_Premultiplied);
             previewPixmap.fill(0);
 
@@ -275,7 +276,7 @@ kpToolWidgetBrush::DrawPackage kpToolWidgetBrush::drawFunctionDataForRowCol (
 kpToolWidgetBrush::DrawPackage kpToolWidgetBrush::drawFunctionData (
         const kpColor &color) const
 {
-    return drawFunctionDataForRowCol (color, selectedRow (), selectedCol ());
+    return drawFunctionDataForRowCol (color, selectedRow () / BRUSH_SIZE_NUM_COLS, selectedRow () % BRUSH_SIZE_NUM_COLS);
 }
 
 //---------------------------------------------------------------------

--- a/widgets/toolbars/options/kpToolWidgetEraserSize.cpp
+++ b/widgets/toolbars/options/kpToolWidgetEraserSize.cpp
@@ -84,10 +84,6 @@ kpToolWidgetEraserSize::kpToolWidgetEraserSize (QWidget *parent, const QString &
 {
     for (int i = 0; i < ::NumEraserSizes; i++)
     {
-        if (i == 3 || i == 5) {
-            startNewOptionRow ();
-        }
-
         const int s = ::EraserSizes [i];
 
         QImage previewPixmap (s, s, QImage::Format_ARGB32_Premultiplied);

--- a/widgets/toolbars/options/kpToolWidgetFillStyle.cpp
+++ b/widgets/toolbars/options/kpToolWidgetFillStyle.cpp
@@ -54,8 +54,6 @@ kpToolWidgetFillStyle::kpToolWidgetFillStyle (QWidget *parent, const QString &na
                                   (width () - 2/*margin*/) * 3 / 4,
                                   (height () - 2/*margin*/ - 2/*spacing*/) * 3 / (3 * 4));
         addOption (pixmap, fillStyleName (static_cast<FillStyle> (i))/*tooltip*/);
-
-        startNewOptionRow ();
     }
 
     finishConstruction (0, 0);

--- a/widgets/toolbars/options/kpToolWidgetLineWidth.cpp
+++ b/widgets/toolbars/options/kpToolWidgetLineWidth.cpp
@@ -59,7 +59,6 @@ kpToolWidgetLineWidth::kpToolWidgetLineWidth (QWidget *parent, const QString &na
 
         addOption(QPixmap::fromImage(std::move(image)),
                   QString::number(lineWidths[i]));
-        startNewOptionRow ();
     }
 
     finishConstruction (0, 0);

--- a/widgets/toolbars/options/kpToolWidgetOpaqueOrTransparent.cpp
+++ b/widgets/toolbars/options/kpToolWidgetOpaqueOrTransparent.cpp
@@ -40,7 +40,6 @@ kpToolWidgetOpaqueOrTransparent::kpToolWidgetOpaqueOrTransparent (QWidget *paren
     : kpToolWidgetBase (parent, name)
 {
     addOption (QStringLiteral(":/icons/option_opaque"), i18n ("Opaque")/*tooltip*/);
-    startNewOptionRow ();
     addOption (QStringLiteral(":/icons/option_transparent"), i18n ("Transparent")/*tooltip*/);
 
     finishConstruction (0, 0);

--- a/widgets/toolbars/options/kpToolWidgetSpraycanSize.cpp
+++ b/widgets/toolbars/options/kpToolWidgetSpraycanSize.cpp
@@ -45,7 +45,7 @@
 static int spraycanSizes [] = {9, 17, 29};
 
 kpToolWidgetSpraycanSize::kpToolWidgetSpraycanSize (QWidget *parent, const QString &name)
-    : kpToolWidgetBase_Ribbon (parent, name)
+    : kpToolWidgetBase (parent, name)
 {
 #if DEBUG_KP_TOOL_WIDGET_SPRAYCAN_SIZE
     qCDebug(kpLogWidgets) << "kpToolWidgetSpraycanSize::kpToolWidgetSpraycanSize() CALLED!";
@@ -107,7 +107,7 @@ int kpToolWidgetSpraycanSize::spraycanSize () const
 // protected slot virtual [base kpToolWidgetBase]
 bool kpToolWidgetSpraycanSize::setSelected (int row, int col, bool saveAsDefault)
 {
-    const bool ret = kpToolWidgetBase_Ribbon::setSelected (row, col, saveAsDefault);
+    const bool ret = kpToolWidgetBase::setSelected (row, col, saveAsDefault);
     if (ret) {
         Q_EMIT spraycanSizeChanged (spraycanSize ());
     }

--- a/widgets/toolbars/options/kpToolWidgetSpraycanSize.cpp
+++ b/widgets/toolbars/options/kpToolWidgetSpraycanSize.cpp
@@ -45,7 +45,7 @@
 static int spraycanSizes [] = {9, 17, 29};
 
 kpToolWidgetSpraycanSize::kpToolWidgetSpraycanSize (QWidget *parent, const QString &name)
-    : kpToolWidgetBase (parent, name)
+    : kpToolWidgetBase_Ribbon (parent, name)
 {
 #if DEBUG_KP_TOOL_WIDGET_SPRAYCAN_SIZE
     qCDebug(kpLogWidgets) << "kpToolWidgetSpraycanSize::kpToolWidgetSpraycanSize() CALLED!";
@@ -90,9 +90,6 @@ kpToolWidgetSpraycanSize::kpToolWidgetSpraycanSize (QWidget *parent, const QStri
         pixmap.setMask (mask);
         
         addOption (pixmap, i18n ("%1x%2", s, s)/*tooltip*/);
-        if (i == 1) {
-            startNewOptionRow ();
-        }
     }
 
     finishConstruction (0, 0);
@@ -110,7 +107,7 @@ int kpToolWidgetSpraycanSize::spraycanSize () const
 // protected slot virtual [base kpToolWidgetBase]
 bool kpToolWidgetSpraycanSize::setSelected (int row, int col, bool saveAsDefault)
 {
-    const bool ret = kpToolWidgetBase::setSelected (row, col, saveAsDefault);
+    const bool ret = kpToolWidgetBase_Ribbon::setSelected (row, col, saveAsDefault);
     if (ret) {
         Q_EMIT spraycanSizeChanged (spraycanSize ());
     }

--- a/widgets/toolbars/options/kpToolWidgetSpraycanSize.h
+++ b/widgets/toolbars/options/kpToolWidgetSpraycanSize.h
@@ -32,8 +32,7 @@
 
 #include "kpToolWidgetBase.h"
 
-
-class kpToolWidgetSpraycanSize : public kpToolWidgetBase
+class kpToolWidgetSpraycanSize : public kpToolWidgetBase_Ribbon
 {
 Q_OBJECT
 

--- a/widgets/toolbars/options/kpToolWidgetSpraycanSize.h
+++ b/widgets/toolbars/options/kpToolWidgetSpraycanSize.h
@@ -32,7 +32,7 @@
 
 #include "kpToolWidgetBase.h"
 
-class kpToolWidgetSpraycanSize : public kpToolWidgetBase_Ribbon
+class kpToolWidgetSpraycanSize : public kpToolWidgetBase
 {
 Q_OBJECT
 


### PR DESCRIPTION
I've modified KolourPaint to have a Windows-style Ribbon UI using the [SARibbon Qt library](https://github.com/czyt1988/SARibbon). The old toolbars have been kept (mostly*) intact and the app can still revert to using them by disabling the ribbon from the `Settings` menu. This fork still uses Qt 5 because I didn't have Qt 6 installed on my system, however seeing as both KolourPaint and SARibbon support Qt 6 I doubt that rebasing this branch to the latest KolourPaint codebase would require many modificaitons.

_*except for kpToolToolBar, that has been turned into a dummy class and is used to setup the ribbon. Having both the original and the ribbon in the same app would require duplicating the class which would take some work. Whether using the old kpToolToolBar still needs to be an option is up to the maintainers to decide._

Since many actions in the ribbon (especially on the `Image` page) were previously only in drop down menus, they are currently missing icons.

![](https://github.com/user-attachments/assets/da8521cc-ce3b-40f6-9bdc-2eb16436d269)

The ribbon in the screenshot uses its own QSS theme ([list of themes](https://github.com/czyt1988/SARibbon?tab=readme-ov-file#features)) which does not integrate with the native Qt theme. Commenting out the [line](https://github.com/albert-tomanek/kolourpaint/blob/f1ccc4434f79a9b7b07ac99ab610741f9a2507ac/mainWindow/kpMainWindow.cpp#L261) that sets the theme disables this, but some ribbon elements may not look the way they are meant to unless the Qt theme was written to support SARibbon.
